### PR TITLE
Fix stale coupon labels and right-align line pricing discount amounts.

### DIFF
--- a/helpers/invoice/pos_invoice_amount_summary.php
+++ b/helpers/invoice/pos_invoice_amount_summary.php
@@ -24,7 +24,10 @@ function pos_invoice_custom_discount_label(array $posMeta): string
 
 function pos_invoice_coupon_label(array $posMeta): string
 {
-    $raw = trim((string)($posMeta['coupon_display_name'] ?? ''));
+    $raw = pos_order_pick_best_coupon_raw([
+        $posMeta['coupon_raw'] ?? '',
+        $posMeta['coupon_display_name'] ?? '',
+    ]);
 
     return pos_order_coupon_discount_label($raw);
 }
@@ -35,19 +38,48 @@ function pos_invoice_coupon_label(array $posMeta): string
 function pos_order_parse_coupon_code(string $couponRaw): string
 {
     $couponRaw = trim($couponRaw);
-    if ($couponRaw === '') {
+    if ($couponRaw === '' || $couponRaw === '0') {
         return '';
     }
 
     if (str_contains($couponRaw, '|')) {
         $parts = explode('|', $couponRaw);
         $code = trim((string)($parts[0] ?? ''));
-        if ($code !== '') {
+        if ($code !== '' && $code !== '0') {
             return $code;
         }
     }
 
     return $couponRaw;
+}
+
+/**
+ * Prefer full Exotic coupon string (UNI37|c|1550) over stale vp_order_info "0".
+ *
+ * @param list<mixed> $candidates
+ */
+function pos_order_pick_best_coupon_raw(array $candidates): string
+{
+    $normalized = [];
+    foreach ($candidates as $candidate) {
+        $raw = trim((string)$candidate);
+        if ($raw === '' || $raw === '0') {
+            continue;
+        }
+        $normalized[] = $raw;
+    }
+
+    if ($normalized === []) {
+        return '';
+    }
+
+    foreach ($normalized as $raw) {
+        if (str_contains($raw, '|')) {
+            return $raw;
+        }
+    }
+
+    return $normalized[0];
 }
 
 function pos_order_coupon_discount_label(string $couponRaw): string

--- a/helpers/invoice/pos_order_pricing.php
+++ b/helpers/invoice/pos_order_pricing.php
@@ -95,8 +95,11 @@ function pos_order_resolve_discount_meta(?array $invoice, ?array $orderInfo, arr
     $couponReduce = round((float)($meta['coupon_discount'] ?? 0), 2);
     $giftReduce = round((float)($meta['gift_discount'] ?? 0), 2);
     $cashReduce = round((float)($meta['cash_discount'] ?? 0), 2);
-    $couponName = trim((string)($meta['coupon_display_name'] ?? ''));
     $giftName = trim((string)($meta['gift_voucher_name'] ?? ''));
+    $couponCandidates = [
+        $meta['coupon_raw'] ?? '',
+        $meta['coupon_display_name'] ?? '',
+    ];
 
     if (is_array($orderInfo)) {
         if ($couponReduce <= 0) {
@@ -108,9 +111,7 @@ function pos_order_resolve_discount_meta(?array $invoice, ?array $orderInfo, arr
         if ($cashReduce <= 0) {
             $cashReduce = round((float)($orderInfo['custom_reduce'] ?? 0), 2);
         }
-        if ($couponName === '') {
-            $couponName = trim((string)($orderInfo['coupon'] ?? ''));
-        }
+        $couponCandidates[] = $orderInfo['coupon'] ?? '';
         if ($giftName === '') {
             $giftName = trim((string)($orderInfo['giftvoucher'] ?? ''));
         }
@@ -129,13 +130,13 @@ function pos_order_resolve_discount_meta(?array $invoice, ?array $orderInfo, arr
         if ($cashReduce <= 0) {
             $cashReduce = max($cashReduce, round((float)($orderRow['custom_reduce'] ?? 0), 2));
         }
-        if ($couponName === '') {
-            $couponName = trim((string)($orderRow['coupon'] ?? ''));
-        }
+        $couponCandidates[] = $orderRow['coupon'] ?? '';
         if ($giftName === '') {
             $giftName = trim((string)($orderRow['giftvoucher'] ?? ''));
         }
     }
+
+    $couponRaw = pos_order_pick_best_coupon_raw($couponCandidates);
 
     if ($couponReduce > 0) {
         $meta['coupon_discount'] = $couponReduce;
@@ -146,9 +147,9 @@ function pos_order_resolve_discount_meta(?array $invoice, ?array $orderInfo, arr
     if ($cashReduce > 0) {
         $meta['cash_discount'] = $cashReduce;
     }
-    if ($couponName !== '') {
-        $meta['coupon_display_name'] = pos_order_parse_coupon_code($couponName);
-        $meta['coupon_raw'] = $couponName;
+    if ($couponRaw !== '') {
+        $meta['coupon_display_name'] = pos_order_parse_coupon_code($couponRaw);
+        $meta['coupon_raw'] = $couponRaw;
     }
     if ($giftName !== '') {
         $meta['gift_voucher_name'] = $giftName;
@@ -726,13 +727,11 @@ function pos_order_build_order_level_discount_lines(array $discountMeta, ?array 
     }
 
     if ($coupon > 0.001) {
-        $couponRaw = trim((string)($discountMeta['coupon_raw'] ?? ''));
-        if ($couponRaw === '') {
-            $couponRaw = trim((string)($discountMeta['coupon_display_name'] ?? ''));
-        }
-        if ($couponRaw === '' && is_array($orderInfo)) {
-            $couponRaw = trim((string)($orderInfo['coupon'] ?? ''));
-        }
+        $couponRaw = pos_order_pick_best_coupon_raw([
+            $discountMeta['coupon_raw'] ?? '',
+            $discountMeta['coupon_display_name'] ?? '',
+            is_array($orderInfo) ? ($orderInfo['coupon'] ?? '') : '',
+        ]);
         $lines[] = [
             'label' => pos_order_coupon_discount_label($couponRaw),
             'amount' => $coupon,

--- a/views/posorders/partials/line_item_pricing.php
+++ b/views/posorders/partials/line_item_pricing.php
@@ -38,40 +38,40 @@ $showComponentBreakdown = count($pricingComponents) > 0 && ($customReduce > 0.00
                 </tbody>
             </table>
         </div>
-        <div class="grid grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-x-8 border-t border-gray-200 pt-3">
+        <div class="space-y-2 border-t border-gray-200 pt-3">
             <?php if ($orderDiscountLines !== []): ?>
                 <?php foreach ($orderDiscountLines as $discountLine): ?>
-                    <div class="flex items-center justify-between gap-4 py-1">
+                    <div class="flex w-full items-center justify-between gap-4 py-1">
                         <span class="text-gray-600"><?php echo htmlspecialchars((string)($discountLine['label'] ?? 'Custom Discount:')); ?></span>
-                        <span class="tabular-nums font-semibold text-emerald-700"><?php echo $formatAmount((float)($discountLine['amount'] ?? 0)); ?></span>
+                        <span class="shrink-0 text-right tabular-nums font-semibold text-emerald-700"><?php echo $formatAmount((float)($discountLine['amount'] ?? 0)); ?></span>
                     </div>
                 <?php endforeach; ?>
             <?php elseif ($customReduce > 0.001): ?>
-                <div class="flex items-center justify-between gap-4 py-1">
+                <div class="flex w-full items-center justify-between gap-4 py-1">
                     <span class="text-gray-600">Custom Discount:</span>
-                    <span class="tabular-nums font-semibold text-emerald-700"><?php echo $formatAmount($customReduce); ?></span>
+                    <span class="shrink-0 text-right tabular-nums font-semibold text-emerald-700"><?php echo $formatAmount($customReduce); ?></span>
                 </div>
             <?php endif; ?>
         </div>
     <?php else: ?>
-        <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-x-8 sm:gap-y-3">
-            <div class="flex items-center justify-between gap-4 py-1">
+        <div class="space-y-3">
+            <div class="flex w-full items-center justify-between gap-4 py-1">
                 <span class="text-gray-600">Listing price (unit)</span>
-                <span class="tabular-nums font-medium text-gray-900"><?php echo $formatAmount((float)($linePricing['listing_price_unit'] ?? 0)); ?></span>
+                <span class="shrink-0 text-right tabular-nums font-medium text-gray-900"><?php echo $formatAmount((float)($linePricing['listing_price_unit'] ?? 0)); ?></span>
             </div>
             <?php if (((float)($linePricing['discount_amount'] ?? 0)) > 0.001): ?>
-                <div class="flex items-center justify-between gap-4 py-1">
+                <div class="flex w-full items-center justify-between gap-4 py-1">
                     <span class="text-gray-600">List discount</span>
-                    <span class="tabular-nums font-semibold text-emerald-700">- <?php echo $formatAmount((float)($linePricing['discount_amount'] ?? 0)); ?></span>
+                    <span class="shrink-0 text-right tabular-nums font-semibold text-emerald-700">- <?php echo $formatAmount((float)($linePricing['discount_amount'] ?? 0)); ?></span>
                 </div>
             <?php endif; ?>
         </div>
     <?php endif; ?>
 
-    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-x-8 sm:gap-y-3 mt-3 border-t border-gray-200 pt-3">
-        <div class="flex items-center justify-between gap-4 sm:col-span-2">
+    <div class="mt-3 border-t border-gray-200 pt-3">
+        <div class="flex w-full items-center justify-between gap-4">
             <span class="font-semibold text-gray-800">Net chargeable amount</span>
-            <span class="tabular-nums text-[15px] font-bold text-gray-900"><?php echo $formatAmount((float)($linePricing['chargeable_value'] ?? 0)); ?></span>
+            <span class="shrink-0 text-right tabular-nums text-[15px] font-bold text-gray-900"><?php echo $formatAmount((float)($linePricing['chargeable_value'] ?? 0)); ?></span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Prefer full Exotic coupon strings over vp_order_info 0 values, and use full-width rows so discount amounts align with list prices.