### PR TITLE
Add inline stock refresh for fresh items on the stock report.

### DIFF
--- a/controllers/POSRegisterController.php
+++ b/controllers/POSRegisterController.php
@@ -1916,6 +1916,18 @@ class POSRegisterController
         $itemCode = trim((string) ($product['item_code'] ?? ''));
         $label = $sku !== '' ? $sku : ($itemCode !== '' ? $itemCode : ('#' . $productId));
 
+        $refreshEligibility = $productModel->getStockReportInlineRefreshEligibility($productId);
+        if (empty($refreshEligibility['eligible'])) {
+            return [
+                'success' => false,
+                'message' => 'Stock refresh is only available for items with no stock movements, or a single movement at zero balance.',
+                'product_id' => $productId,
+                'sku' => $sku,
+                'label' => $label,
+                'movement_count' => (int) ($refreshEligibility['movement_count'] ?? 0),
+            ];
+        }
+
         $defaultWarehouseId = $this->resolveDefaultWarehouseIdForStockRefresh($conn);
         if ($defaultWarehouseId <= 0) {
             return [

--- a/helpers/stock_report_filters.php
+++ b/helpers/stock_report_filters.php
@@ -123,6 +123,21 @@ function appendStockReportSearchFilterSql(
     return true;
 }
 
+/**
+ * Whether a product may use inline stock-report refresh (no ledger history, or one zero-balance row).
+ */
+function isStockReportInlineRefreshEligible(int $movementCount, ?float $soleMovementRunningStock): bool
+{
+    if ($movementCount <= 0) {
+        return true;
+    }
+    if ($movementCount === 1) {
+        return abs((float) $soleMovementRunningStock) < 0.00001;
+    }
+
+    return false;
+}
+
 function appendStockReportLocationFilterSql(
     string &$where,
     array &$params,

--- a/models/pos/pos.php
+++ b/models/pos/pos.php
@@ -461,6 +461,13 @@ class pos
 
         return [
             'join' => $join,
+            'stats_join' => "
+            LEFT JOIN (
+                SELECT product_id, COUNT(*) AS movement_count, MIN(running_stock) AS min_running_stock
+                FROM vp_stock_movements
+                GROUP BY product_id
+            ) sm_stats ON sm_stats.product_id = p.id
+            ",
             'where' => $where,
             'params' => $params,
             'types' => $types,
@@ -485,6 +492,7 @@ class pos
         }
 
         $join = $query['join'];
+        $statsJoin = $query['stats_join'] ?? '';
         $where = $query['where'];
         $params = $query['params'];
         $types = $query['types'];
@@ -503,9 +511,12 @@ class pos
                 ({$this->sqlPosIndiaSellBaseExpr('p')} * (1 + IFNULL(p.gst, 0) / 100)) AS sell_price,
                 p.cost_price,
                 COALESCE(sm.running_stock, 0) AS stock_qty,
-                sm.location AS location
+                sm.location AS location,
+                COALESCE(sm_stats.movement_count, 0) AS movement_count,
+                sm_stats.min_running_stock AS min_running_stock
             FROM vp_products p
             $join
+            $statsJoin
             LEFT JOIN `category` cat ON cat.category = p.groupname
             $where
             ORDER BY COALESCE(sm.running_stock, 0) ASC, p.title ASC

--- a/models/product/product.php
+++ b/models/product/product.php
@@ -2327,6 +2327,51 @@ class product
     }
 
     /**
+     * Ledger state for stock-report inline refresh (all warehouses, by product_id).
+     *
+     * @return array{eligible:bool,movement_count:int,sole_movement_running_stock:?float}
+     */
+    public function getStockReportInlineRefreshEligibility(int $productId): array
+    {
+        require_once dirname(__DIR__, 2) . '/helpers/stock_report_filters.php';
+
+        $productId = (int) $productId;
+        if ($productId <= 0) {
+            return [
+                'eligible' => false,
+                'movement_count' => 0,
+                'sole_movement_running_stock' => null,
+            ];
+        }
+
+        $stmt = $this->db->prepare(
+            'SELECT COUNT(*) AS movement_count, MIN(running_stock) AS min_running_stock
+             FROM vp_stock_movements
+             WHERE product_id = ?'
+        );
+        if (!$stmt) {
+            return [
+                'eligible' => false,
+                'movement_count' => 0,
+                'sole_movement_running_stock' => null,
+            ];
+        }
+        $stmt->bind_param('i', $productId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        $movementCount = (int) ($row['movement_count'] ?? 0);
+        $soleBalance = $movementCount === 1 ? (float) ($row['min_running_stock'] ?? 0) : null;
+
+        return [
+            'eligible' => isStockReportInlineRefreshEligible($movementCount, $soleBalance),
+            'movement_count' => $movementCount,
+            'sole_movement_running_stock' => $soleBalance,
+        ];
+    }
+
+    /**
      * Product detail Refresh from API stock rules (when no ledger history yet).
      */
     private function shouldRefreshApiSyncStock(?array $existingBase, bool $freshlyImportedInThisRun): bool

--- a/views/pos_register/stock_report.php
+++ b/views/pos_register/stock_report.php
@@ -312,6 +312,9 @@ $pgBase = '?page=pos_register&action=stock-report' . $qs;
               <?php
                 $productId = (int)($r['id'] ?? 0);
                 $skuLabel = trim((string)($r['sku'] ?? $r['item_code'] ?? ''));
+                $movementCount = (int)($r['movement_count'] ?? 0);
+                $soleMovementBalance = $movementCount === 1 ? (float)($r['min_running_stock'] ?? 0) : null;
+                $canInlineStockRefresh = isStockReportInlineRefreshEligible($movementCount, $soleMovementBalance);
               ?>
               <tr class="odd:bg-white even:bg-gray-50/40 hover:bg-amber-50/50 transition-colors" data-product-id="<?= $productId ?>">
                 <td class="px-5 py-4 align-top">
@@ -350,14 +353,27 @@ $pgBase = '?page=pos_register&action=stock-report' . $qs;
                     <span class="inline-flex rounded-md bg-gray-100 px-2 py-1 text-xs text-gray-500">N/A</span>
                   <?php endif; ?>
                 </td>
-                <td class="px-5 py-4 align-top">
-                  <?php if ($qty <= 0): ?>
-                    <span class="inline-flex rounded-full bg-red-100 px-3 py-1.5 text-xs font-semibold text-red-700">Out (0)</span>
-                  <?php elseif ($qty <= 5): ?>
-                    <span class="inline-flex rounded-full bg-amber-100 px-3 py-1.5 text-xs font-semibold text-amber-700">Low (<?= $qty ?>)</span>
-                  <?php else: ?>
-                    <span class="inline-flex rounded-full bg-green-100 px-3 py-1.5 text-xs font-semibold text-green-700">In (<?= $qty ?>)</span>
-                  <?php endif; ?>
+                <td class="px-5 py-4 align-top stock-report-stock-cell" data-product-id="<?= $productId ?>">
+                  <div class="inline-flex items-center gap-2 flex-wrap">
+                    <?php if ($qty <= 0): ?>
+                      <span class="stock-report-stock-badge inline-flex rounded-full bg-red-100 px-3 py-1.5 text-xs font-semibold text-red-700">Out (0)</span>
+                    <?php elseif ($qty <= 5): ?>
+                      <span class="stock-report-stock-badge inline-flex rounded-full bg-amber-100 px-3 py-1.5 text-xs font-semibold text-amber-700">Low (<?= $qty ?>)</span>
+                    <?php else: ?>
+                      <span class="stock-report-stock-badge inline-flex rounded-full bg-green-100 px-3 py-1.5 text-xs font-semibold text-green-700">In (<?= $qty ?>)</span>
+                    <?php endif; ?>
+                    <?php if ($canInlineStockRefresh): ?>
+                      <button
+                        type="button"
+                        class="stock-report-inline-refresh inline-flex h-7 w-7 items-center justify-center rounded-md border border-orange-200 bg-orange-50 text-orange-700 hover:bg-orange-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-1 transition disabled:opacity-50 disabled:pointer-events-none"
+                        data-product-id="<?= $productId ?>"
+                        data-sku-label="<?= htmlspecialchars($skuLabel, ENT_QUOTES, 'UTF-8') ?>"
+                        title="Refresh stock from API (fresh item with no ledger history)"
+                        aria-label="Refresh stock from API for <?= htmlspecialchars($skuLabel, ENT_QUOTES, 'UTF-8') ?>">
+                        <i class="fas fa-sync-alt text-[11px]" aria-hidden="true"></i>
+                      </button>
+                    <?php endif; ?>
+                  </div>
                 </td>
                 <td class="px-5 py-4 align-top text-sm text-right font-semibold text-gray-900 tabular-nums">₹<?= number_format((float)($r['sell_price'] ?? 0), 2) ?></td>
                 <td class="px-5 py-4 align-top text-sm text-gray-800 max-w-[15rem] break-words leading-snug"><?= htmlspecialchars($r['title'] ?? '') ?></td>
@@ -606,6 +622,55 @@ $pgBase = '?page=pos_register&action=stock-report' . $qs;
       chunks.push(ids.slice(i, i + size));
     }
     return chunks;
+  }
+
+  async function refreshStockReportRowInline(btn) {
+    const productId = parseInt(String(btn.dataset.productId || '0'), 10);
+    const skuLabel = String(btn.dataset.skuLabel || ('#' + productId)).trim();
+    if (productId <= 0) return;
+
+    const confirmed = window.confirm(
+      'Refresh stock for ' + skuLabel + '?\n\n' + STOCK_REPORT_REFRESH_CONFIRM
+    );
+    if (!confirmed) return;
+
+    const iconEl = btn.querySelector('i');
+    btn.disabled = true;
+    btn.classList.add('opacity-70', 'cursor-not-allowed');
+    if (iconEl) {
+      iconEl.classList.remove('fa-sync-alt');
+      iconEl.classList.add('fa-spinner', 'fa-spin');
+    }
+
+    try {
+      const res = await fetch('index.php?page=pos_register&action=stock-report-refresh', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+        body: JSON.stringify({ product_id: productId }),
+      });
+      const rawText = await res.text();
+      let data = null;
+      try {
+        data = rawText ? JSON.parse(rawText) : null;
+      } catch (parseErr) {
+        data = null;
+      }
+      if (!data || !data.success) {
+        throw new Error((data && data.message) ? data.message : 'Stock refresh failed.');
+      }
+
+      window.alert(data.message || ('Stock refreshed for ' + skuLabel + '.'));
+      window.location.reload();
+    } catch (err) {
+      window.alert(err && err.message ? err.message : 'Stock refresh failed.');
+      btn.disabled = false;
+      btn.classList.remove('opacity-70', 'cursor-not-allowed');
+      if (iconEl) {
+        iconEl.classList.remove('fa-spinner', 'fa-spin');
+        iconEl.classList.add('fa-sync-alt');
+      }
+    }
   }
 
   function setStockReportBulkUiLocked(locked) {
@@ -1678,6 +1743,13 @@ $pgBase = '?page=pos_register&action=stock-report' . $qs;
       groupSelect.addEventListener('change', syncStockReportGroupFilters);
     }
     syncStockReportGroupFilters();
+
+    document.addEventListener('click', (event) => {
+      const refreshBtn = event.target.closest('.stock-report-inline-refresh');
+      if (!refreshBtn || refreshBtn.disabled) return;
+      event.preventDefault();
+      refreshStockReportRowInline(refreshBtn);
+    });
 
     updateStockReportSelectionUi();
   });


### PR DESCRIPTION
Show a per-row sync icon when a product has no movements or one zero-balance row, reusing the existing API refresh flow.