### PR TITLE
Add country to currency mapping feature

### DIFF
--- a/controllers/CurrencyController.php
+++ b/controllers/CurrencyController.php
@@ -34,12 +34,13 @@ class CurrencyController {
         
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $data = [
-                'currency_code'  => trim($_POST['currency_code'] ?? ''),
-                'currency_name'  => trim($_POST['currency_name'] ?? ''),
-                'currency_unit'  => trim($_POST['currency_unit'] ?? ''),
-                'display_symbol' => trim($_POST['display_symbol'] ?? ''),
-                'rate_import'    => floatval($_POST['rate_import'] ?? 0),
-                'rate_export'    => floatval($_POST['rate_export'] ?? 0)
+                'currency_code'    => trim($_POST['currency_code'] ?? ''),
+                'currency_name'    => trim($_POST['currency_name'] ?? ''),
+                'currency_unit'    => trim($_POST['currency_unit'] ?? ''),
+                'display_symbol'   => trim($_POST['display_symbol'] ?? ''),
+                'mapped_countries' => trim($_POST['mapped_countries'] ?? ''),
+                'rate_import'      => floatval($_POST['rate_import'] ?? 0),
+                'rate_export'      => floatval($_POST['rate_export'] ?? 0)
             ];
             
             $errors = $this->validate($data, $isEdit);
@@ -207,6 +208,7 @@ class CurrencyController {
     public function getAllCurrencies() { return $this->model->getAllCurrencies(); }
     public function getCurrencyById($id) { return $this->model->getCurrencyById($id); }
     public function getCurrencyByCode($code) { return $this->model->getCurrencyByCode($code); }
+    public function getCurrencyByCountryCode($countryCode) { return $this->model->getCurrencyByCountryCode($countryCode); }
     public function addCurrency($data) { return $this->model->addCurrency($data); }
     public function updateCurrency($id, $data) { return $this->model->updateCurrency($id, $data); }
     public function deactivateCurrency($id) { return $this->model->deactivateCurrency($id); }

--- a/models/currency/CurrencyModel.php
+++ b/models/currency/CurrencyModel.php
@@ -7,6 +7,52 @@ class CurrencyModel
     public function __construct($database)
     {
         $this->db = $database;
+        $this->ensureMappedCountriesColumn();
+    }
+
+    /**
+     * Ensure mapped_countries column exists in currency_master
+     */
+    private function ensureMappedCountriesColumn(): void
+    {
+        static $checked = false;
+        if ($checked) return;
+        $checked = true;
+
+        if ($this->db) {
+            $check = @$this->db->query("SHOW COLUMNS FROM currency_master LIKE 'mapped_countries'");
+            if ($check && $check->num_rows === 0) {
+                @$this->db->query("ALTER TABLE currency_master ADD COLUMN mapped_countries TEXT NULL DEFAULT NULL AFTER display_symbol");
+            }
+        }
+    }
+
+    /**
+     * Get default mapped countries for standard currency codes
+     */
+    public static function getDefaultMappedCountries(string $code): string
+    {
+        $code = strtoupper(trim($code));
+        $defaults = [
+            'EUR' => 'DE, FR, IT, ES, NL, BE, AT, FI, GR, IE, PT, SK, SI, EE, LV, LT, CY, MT, LU, HR',
+            'GBP' => 'GB, UK',
+            'DKK' => 'DK',
+            'NOK' => 'NO',
+            'USD' => 'US',
+            'CAD' => 'CA',
+            'AUD' => 'AU',
+            'NZD' => 'NZ',
+            'JPY' => 'JP',
+            'INR' => 'IN',
+            'CHF' => 'CH',
+            'SEK' => 'SE',
+            'SGD' => 'SG',
+            'HKD' => 'HK',
+            'AED' => 'AE',
+            'SAR' => 'SA',
+        ];
+
+        return $defaults[$code] ?? '';
     }
 
     /**
@@ -61,8 +107,8 @@ class CurrencyModel
         }
 
         $query = "INSERT INTO currency_master 
-                  (currency_code, currency_name, currency_unit, display_symbol, rate_import, rate_export, is_active) 
-                  VALUES (?, ?, ?, ?, ?, ?, 1)";
+                  (currency_code, currency_name, currency_unit, display_symbol, mapped_countries, rate_import, rate_export, is_active) 
+                  VALUES (?, ?, ?, ?, ?, ?, ?, 1)";
 
         $stmt = $this->db->prepare($query);
         if (!$stmt) return ['success' => false, 'message' => 'Prepare failed: ' . $this->db->error];
@@ -70,10 +116,11 @@ class CurrencyModel
         $name = trim($data['currency_name'] ?? '');
         $unit = trim($data['currency_unit'] ?? '');
         $symbol = trim($data['display_symbol'] ?? '');
+        $mapped_countries = trim($data['mapped_countries'] ?? self::getDefaultMappedCountries($code));
         $rate_import = floatval($data['rate_import'] ?? 0);
         $rate_export = floatval($data['rate_export'] ?? 0);
 
-        $stmt->bind_param('ssssdd', $code, $name, $unit, $symbol, $rate_import, $rate_export);
+        $stmt->bind_param('sssssdd', $code, $name, $unit, $symbol, $mapped_countries, $rate_import, $rate_export);
         $result = $stmt->execute();
 
         if ($result) {
@@ -98,6 +145,7 @@ class CurrencyModel
                   currency_name = ?, 
                   currency_unit = ?, 
                   display_symbol = ?,
+                  mapped_countries = ?,
                   rate_import = ?, 
                   rate_export = ? 
                   WHERE id = ?";
@@ -105,13 +153,15 @@ class CurrencyModel
         $stmt = $this->db->prepare($query);
         if (!$stmt) return ['success' => false, 'message' => 'Prepare failed: ' . $this->db->error];
 
+        $code = strtoupper(trim($oldCurrency['currency_code']));
         $name = trim($data['currency_name'] ?? $oldCurrency['currency_name']);
         $unit = trim($data['currency_unit'] ?? $oldCurrency['currency_unit']);
         $symbol = trim($data['display_symbol'] ?? ($oldCurrency['display_symbol'] ?? ''));
+        $mapped_countries = isset($data['mapped_countries']) ? trim($data['mapped_countries']) : ($oldCurrency['mapped_countries'] ?? self::getDefaultMappedCountries($code));
         $rate_import = floatval($data['rate_import']);
         $rate_export = floatval($data['rate_export']);
 
-        $stmt->bind_param('sssddi', $name, $unit, $symbol, $rate_import, $rate_export, $id);
+        $stmt->bind_param('ssssddi', $name, $unit, $symbol, $mapped_countries, $rate_import, $rate_export, $id);
         $result = $stmt->execute();
 
         if ($result) {
@@ -132,6 +182,7 @@ class CurrencyModel
                   currency_name = ?, 
                   currency_unit = ?, 
                   display_symbol = ?,
+                  mapped_countries = ?,
                   rate_import = ?, 
                   rate_export = ?,
                   is_active = 1
@@ -140,17 +191,18 @@ class CurrencyModel
         $stmt = $this->db->prepare($query);
         if (!$stmt) return ['success' => false, 'message' => 'Prepare failed'];
 
+        $code = strtoupper($data['currency_code'] ?? '');
         $name = trim($data['currency_name'] ?? '');
         $unit = trim($data['currency_unit'] ?? '');
         $symbol = trim($data['display_symbol'] ?? '');
+        $mapped_countries = trim($data['mapped_countries'] ?? self::getDefaultMappedCountries($code));
         $rate_import = floatval($data['rate_import'] ?? 0);
         $rate_export = floatval($data['rate_export'] ?? 0);
 
-        $stmt->bind_param('sssddi', $name, $unit, $symbol, $rate_import, $rate_export, $id);
+        $stmt->bind_param('ssssddi', $name, $unit, $symbol, $mapped_countries, $rate_import, $rate_export, $id);
         $result = $stmt->execute();
 
         if ($result) {
-            $code = strtoupper($data['currency_code']);
             $this->addRateHistory($code, $rate_import, $rate_export);
             return ['success' => true, 'id' => $id, 'message' => 'Currency reactivated successfully'];
         }
@@ -206,6 +258,43 @@ class CurrencyModel
         $stmt->execute();
         $res = $stmt->get_result();
         return $res ? $res->fetch_all(MYSQLI_ASSOC) : [];
+    }
+
+    /**
+     * Find active currency mapped to a specific country code or country name
+     * (e.g. 'DE', 'FR', 'ES', 'GB', 'DK', 'NO')
+     */
+    public function getCurrencyByCountryCode(string $countryInput): ?array
+    {
+        $countryInput = trim($countryInput);
+        if (empty($countryInput)) return null;
+
+        $all = $this->getAllCurrencies();
+        
+        // 1. Check explicit mapped_countries in database or defaults
+        foreach ($all as $curr) {
+            $mapped = !empty($curr['mapped_countries']) 
+                ? $curr['mapped_countries'] 
+                : self::getDefaultMappedCountries($curr['currency_code']);
+
+            if (!empty($mapped)) {
+                $tags = array_map('trim', explode(',', $mapped));
+                foreach ($tags as $tag) {
+                    if (strcasecmp($tag, $countryInput) === 0) {
+                        return $curr;
+                    }
+                }
+            }
+        }
+
+        // 2. Direct currency code match (e.g. USD, EUR, GBP, DKK, NOK)
+        foreach ($all as $curr) {
+            if (strcasecmp($curr['currency_code'], $countryInput) === 0) {
+                return $curr;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/sql/alter_currency_master_add_mapped_countries.sql
+++ b/sql/alter_currency_master_add_mapped_countries.sql
@@ -1,0 +1,5 @@
+-- Add mapped_countries column to currency_master table
+-- Stores comma-separated ISO country codes or names mapped to a currency (e.g. EUR -> DE, FR, IT, ES, NL, BE...)
+
+ALTER TABLE `currency_master`
+    ADD COLUMN `mapped_countries` TEXT NULL DEFAULT NULL AFTER `display_symbol`;

--- a/views/currency/currency_form.php
+++ b/views/currency/currency_form.php
@@ -14,11 +14,12 @@ if ($isEdit) {
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $data = [
-        'currency_code' => trim($_POST['currency_code'] ?? ''),
-        'currency_name' => trim($_POST['currency_name'] ?? ''),
-        'currency_unit' => trim($_POST['currency_unit'] ?? ''),
-        'rate_import' => floatval($_POST['rate_import'] ?? 0),
-        'rate_export' => floatval($_POST['rate_export'] ?? 0)
+        'currency_code'    => trim($_POST['currency_code'] ?? ''),
+        'currency_name'    => trim($_POST['currency_name'] ?? ''),
+        'currency_unit'    => trim($_POST['currency_unit'] ?? ''),
+        'mapped_countries' => trim($_POST['mapped_countries'] ?? ''),
+        'rate_import'      => floatval($_POST['rate_import'] ?? 0),
+        'rate_export'      => floatval($_POST['rate_export'] ?? 0)
     ];
     
     $errors = $currencyController->validate($data, $isEdit);
@@ -113,6 +114,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                        value="<?php echo $currency ? htmlspecialchars($currency['currency_unit']) : ''; ?>" required>
             </div>
             
+            <div class="form-group">
+                <label for="mapped_countries">Mapped Countries / Country Codes</label>
+                <?php
+                    $codeVal = $currency ? strtoupper($currency['currency_code']) : '';
+                    $defaultMapped = CurrencyModel::getDefaultMappedCountries($codeVal);
+                    $mappedVal = ($currency && array_key_exists('mapped_countries', $currency) && $currency['mapped_countries'] !== null) 
+                                 ? $currency['mapped_countries'] 
+                                 : $defaultMapped;
+                ?>
+                <input type="text" id="mapped_countries" name="mapped_countries" 
+                       value="<?php echo htmlspecialchars($mappedVal); ?>" 
+                       placeholder="e.g. DE, FR, IT, ES, NL, BE, AT, FI or GB, UK or DK or NO">
+                <div class="currency-code-note">
+                    Comma-separated list of country codes or country names mapped to this currency (e.g., Eurozone countries for EUR, UK for GBP, Denmark for DKK, Norway for NOK).
+                </div>
+                <div style="margin-top: 8px; display: flex; gap: 6px; flex-wrap: wrap; align-items: center;">
+                    <span style="font-size: 11px; font-weight: bold; color: #666;">Quick Presets:</span>
+                    <button type="button" onclick="setPreset('DE, FR, IT, ES, NL, BE, AT, FI, GR, IE, PT, SK, SI, EE, LV, LT, CY, MT, LU, HR')" style="padding: 3px 8px; font-size: 11px; background: #e2e8f0; color: #334155; border: 1px solid #cbd5e1; border-radius: 4px; cursor: pointer;">Eurozone (EUR)</button>
+                    <button type="button" onclick="setPreset('GB, UK')" style="padding: 3px 8px; font-size: 11px; background: #e2e8f0; color: #334155; border: 1px solid #cbd5e1; border-radius: 4px; cursor: pointer;">UK (GBP)</button>
+                    <button type="button" onclick="setPreset('DK')" style="padding: 3px 8px; font-size: 11px; background: #e2e8f0; color: #334155; border: 1px solid #cbd5e1; border-radius: 4px; cursor: pointer;">Denmark (DKK)</button>
+                    <button type="button" onclick="setPreset('NO')" style="padding: 3px 8px; font-size: 11px; background: #e2e8f0; color: #334155; border: 1px solid #cbd5e1; border-radius: 4px; cursor: pointer;">Norway (NOK)</button>
+                    <button type="button" onclick="setPreset('US')" style="padding: 3px 8px; font-size: 11px; background: #e2e8f0; color: #334155; border: 1px solid #cbd5e1; border-radius: 4px; cursor: pointer;">USA (USD)</button>
+                </div>
+            </div>
+            
             <div class="form-row">
                 <div class="form-group">
                     <label for="rate_import">Import Rate *</label>
@@ -133,5 +159,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         
         <a href="currency_list.php" class="btn-back">Back to List</a>
     </div>
+
+    <script>
+    function setPreset(val) {
+        var el = document.getElementById('mapped_countries');
+        if (el) {
+            el.value = val;
+        }
+    }
+    </script>
 </body>
 </html>

--- a/views/currency/currency_list.php
+++ b/views/currency/currency_list.php
@@ -72,17 +72,39 @@ if (isset($_GET['delete']) && !empty($_GET['delete'])) {
                         <th>Code</th>
                         <th>Name</th>
                         <th>Unit</th>
+                        <th>Mapped Countries</th>
                         <th>Import Rate</th>
                         <th>Export Rate</th>
                         <th>Actions</th>
                     </tr>
                 </thead>
                 <tbody>
-                    <?php foreach ($currencies as $curr): ?>
+                    <?php foreach ($currencies as $curr): 
+                        $mappedRaw = !empty($curr['mapped_countries']) ? $curr['mapped_countries'] : CurrencyModel::getDefaultMappedCountries($curr['currency_code']);
+                        $mappedList = array_filter(array_map('trim', explode(',', $mappedRaw)));
+                    ?>
                         <tr>
                             <td><strong><?php echo strtoupper($curr['currency_code']); ?></strong></td>
                             <td><?php echo htmlspecialchars($curr['currency_name']); ?></td>
                             <td><?php echo htmlspecialchars($curr['currency_unit']); ?></td>
+                            <td>
+                                <?php if (!empty($mappedList)): ?>
+                                    <div style="display: flex; flex-wrap: wrap; gap: 4px; max-width: 250px;" title="<?php echo htmlspecialchars(implode(', ', $mappedList)); ?>">
+                                        <?php foreach (array_slice($mappedList, 0, 8) as $tag): ?>
+                                            <span style="background: #e2e8f0; color: #1e293b; padding: 2px 6px; border-radius: 4px; font-size: 11px; font-weight: 600; font-family: monospace;">
+                                                <?php echo htmlspecialchars($tag); ?>
+                                            </span>
+                                        <?php endforeach; ?>
+                                        <?php if (count($mappedList) > 8): ?>
+                                            <span style="background: #cbd5e1; color: #475569; padding: 2px 6px; border-radius: 4px; font-size: 11px; font-weight: 600;">
+                                                +<?php echo count($mappedList) - 8; ?> more
+                                            </span>
+                                        <?php endif; ?>
+                                    </div>
+                                <?php else: ?>
+                                    <span style="color: #94a3b8; font-size: 12px; font-style: italic;">None mapped</span>
+                                <?php endif; ?>
+                            </td>
                             <td><?php echo number_format($curr['rate_import'], 6); ?></td>
                             <td><?php echo number_format($curr['rate_export'], 6); ?></td>
                             <td>

--- a/views/currency/form.php
+++ b/views/currency/form.php
@@ -62,6 +62,31 @@
                        value="<?php echo $currency ? htmlspecialchars($currency['currency_unit']) : ''; ?>" required>
             </div>
             
+            <div class="form-group">
+                <label for="mapped_countries">Mapped Countries / Country Codes</label>
+                <?php
+                    $codeVal = $currency ? strtoupper($currency['currency_code']) : '';
+                    $defaultMapped = CurrencyModel::getDefaultMappedCountries($codeVal);
+                    $mappedVal = ($currency && array_key_exists('mapped_countries', $currency) && $currency['mapped_countries'] !== null) 
+                                 ? $currency['mapped_countries'] 
+                                 : $defaultMapped;
+                ?>
+                <input type="text" id="mapped_countries" name="mapped_countries" 
+                       value="<?php echo htmlspecialchars($mappedVal); ?>" 
+                       placeholder="e.g. DE, FR, IT, ES, NL, BE, AT, FI or GB, UK or DK or NO">
+                <div class="currency-code-note">
+                    Comma-separated list of country codes or country names mapped to this currency (e.g., Eurozone countries for EUR, UK for GBP, Denmark for DKK, Norway for NOK).
+                </div>
+                <div style="margin-top: 8px; display: flex; gap: 6px; flex-wrap: wrap; align-items: center;">
+                    <span style="font-size: 11px; font-weight: bold; color: #666;">Quick Presets:</span>
+                    <button type="button" onclick="setPreset('DE, FR, IT, ES, NL, BE, AT, FI, GR, IE, PT, SK, SI, EE, LV, LT, CY, MT, LU, HR')" style="padding: 3px 8px; font-size: 11px; background: #e2e8f0; color: #334155; border: 1px solid #cbd5e1; border-radius: 4px; cursor: pointer;">Eurozone (EUR)</button>
+                    <button type="button" onclick="setPreset('GB, UK')" style="padding: 3px 8px; font-size: 11px; background: #e2e8f0; color: #334155; border: 1px solid #cbd5e1; border-radius: 4px; cursor: pointer;">UK (GBP)</button>
+                    <button type="button" onclick="setPreset('DK')" style="padding: 3px 8px; font-size: 11px; background: #e2e8f0; color: #334155; border: 1px solid #cbd5e1; border-radius: 4px; cursor: pointer;">Denmark (DKK)</button>
+                    <button type="button" onclick="setPreset('NO')" style="padding: 3px 8px; font-size: 11px; background: #e2e8f0; color: #334155; border: 1px solid #cbd5e1; border-radius: 4px; cursor: pointer;">Norway (NOK)</button>
+                    <button type="button" onclick="setPreset('US')" style="padding: 3px 8px; font-size: 11px; background: #e2e8f0; color: #334155; border: 1px solid #cbd5e1; border-radius: 4px; cursor: pointer;">USA (USD)</button>
+                </div>
+            </div>
+            
             <div class="form-row">
                 <div class="form-group">
                     <label for="rate_import">Import Rate *</label>
@@ -82,4 +107,13 @@
         
         <a href="index.php?page=currency&action=list" class="btn-back">Back to List</a>
     </div>
+
+    <script>
+    function setPreset(val) {
+        var el = document.getElementById('mapped_countries');
+        if (el) {
+            el.value = val;
+        }
+    }
+    </script>
 

--- a/views/currency/list.php
+++ b/views/currency/list.php
@@ -86,17 +86,39 @@ $rateHistory = [];
                     <th>Code</th>
                     <th>Name</th>
                     <th>Unit</th>
+                    <th>Mapped Countries</th>
                     <th>Import Rate (₹)</th>
                     <th>Export Rate (₹)</th>
                     <th>Actions</th>
                 </tr>
             </thead>
             <tbody>
-                <?php foreach ($currencies as $curr): ?>
+                <?php foreach ($currencies as $curr): 
+                    $mappedRaw = !empty($curr['mapped_countries']) ? $curr['mapped_countries'] : CurrencyModel::getDefaultMappedCountries($curr['currency_code']);
+                    $mappedList = array_filter(array_map('trim', explode(',', $mappedRaw)));
+                ?>
                     <tr>
                         <td><strong><?php echo strtoupper($curr['currency_code']); ?></strong></td>
                         <td><?php echo htmlspecialchars($curr['currency_name']); ?></td>
                         <td><?php echo htmlspecialchars($curr['currency_unit']); ?></td>
+                        <td>
+                            <?php if (!empty($mappedList)): ?>
+                                <div style="display: flex; flex-wrap: wrap; gap: 4px; max-width: 280px;" title="<?php echo htmlspecialchars(implode(', ', $mappedList)); ?>">
+                                    <?php foreach (array_slice($mappedList, 0, 8) as $tag): ?>
+                                        <span style="background: #f1f5f9; color: #1e293b; padding: 2px 6px; border-radius: 4px; font-size: 11px; font-weight: 600; border: 1px solid #cbd5e1; font-family: monospace;">
+                                            <?php echo htmlspecialchars($tag); ?>
+                                        </span>
+                                    <?php endforeach; ?>
+                                    <?php if (count($mappedList) > 8): ?>
+                                        <span style="background: #e2e8f0; color: #475569; padding: 2px 6px; border-radius: 4px; font-size: 11px; font-weight: 600;">
+                                            +<?php echo count($mappedList) - 8; ?> more
+                                        </span>
+                                    <?php endif; ?>
+                                </div>
+                            <?php else: ?>
+                                <span style="color: #94a3b8; font-size: 12px; font-style: italic;">None mapped</span>
+                            <?php endif; ?>
+                        </td>
                         <td><strong><?php echo number_format($curr['rate_import'], 6); ?></strong></td>
                         <td><strong><?php echo number_format($curr['rate_export'], 6); ?></strong></td>
                         <td>


### PR DESCRIPTION
Add mapped_countries column to currency_master schema and update CurrencyModel to store, update, and lookup currencies by country code. Add mapped countries input and preset buttons to currency add/edit form, and display mapped country tags in currency list views.