### PR TITLE
Update customer country_of_residence from vp_order_info country

### DIFF
--- a/controllers/POSRegisterController.php
+++ b/controllers/POSRegisterController.php
@@ -1003,6 +1003,7 @@ class POSRegisterController
         if (!empty($_SESSION['pos_customer_id'])) {
             $cid = (int)$_SESSION['pos_customer_id'];
             if ($cid > 0) {
+                $customerModel->ensureCountryOfResidenceForCustomer($cid);
                 $row = $customerModel->getCustomerById($cid);
                 if (!empty($row['id'])) {
                     $nm = (string)($row['name'] ?? '');
@@ -1323,6 +1324,9 @@ class POSRegisterController
         if ($conn instanceof mysqli) {
             $this->ensureHighValueComplianceSchema($conn);
         }
+        if ($customerId > 0) {
+            $customerModel->ensureCountryOfResidenceForCustomer($customerId);
+        }
         $fromVc = $customerId > 0 ? $customerModel->getCustomerBillingShippingForPos($customerId) : ['billing' => [], 'shipping' => []];
         $billingVc = $fromVc['billing'];
         $shippingVc = $fromVc['shipping'];
@@ -1480,6 +1484,7 @@ class POSRegisterController
             $cid = (int)$_SESSION['pos_customer_id'];
             if ($cid > 0) {
                 $customerModel = new Customer($conn);
+                $customerModel->ensureCountryOfResidenceForCustomer($cid);
                 $row = $customerModel->getCustomerById($cid);
                 if (!empty($row['id'])) {
                     $nm = (string)($row['name'] ?? '');
@@ -4366,13 +4371,16 @@ class POSRegisterController
     }
     public function set_customer()
     {
+        $customerId = (int)($_POST['customer_id'] ?? 0);
 
-        // $customerId = $_POST['customer_id'] ?? '';
-        $customerId = $_POST['customer_id'] ?? '';
-
-        if ($customerId) {
+        if ($customerId > 0) {
             $_SESSION['pos_customer_id'] = $customerId;
             unset($_SESSION['pos_customer_form']); // ⭐ VERY IMPORTANT
+
+            global $conn;
+            require_once 'models/customer/Customer.php';
+            $customerModel = new Customer($conn);
+            $customerModel->ensureCountryOfResidenceForCustomer($customerId);
         } else {
             unset($_SESSION['pos_customer_id']);
         }

--- a/models/customer/Customer.php
+++ b/models/customer/Customer.php
@@ -870,6 +870,101 @@ class Customer
     }
 
     /**
+     * Update vp_customers.country_of_residence from vp_order_info.country for a given customer.
+     * If vp_order_info has a country record, use it. Otherwise fallback to $fallbackCountry.
+     */
+    public function updateCustomerCountryOfResidenceFromOrderInfo(int $customerId, string $fallbackCountry = ''): void
+    {
+        if ($customerId <= 0) {
+            return;
+        }
+
+        $country = '';
+        $stmt = $this->conn->prepare('SELECT country FROM vp_order_info WHERE customer_id = ? AND country IS NOT NULL AND TRIM(country) <> \'\' ORDER BY id DESC LIMIT 1');
+        if ($stmt) {
+            $stmt->bind_param('i', $customerId);
+            $stmt->execute();
+            $res = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            if ($res && !empty($res['country'])) {
+                $country = trim((string)$res['country']);
+            }
+        }
+
+        if ($country === '' && trim($fallbackCountry) !== '') {
+            $country = trim($fallbackCountry);
+        }
+
+        if ($country !== '') {
+            $upStmt = $this->conn->prepare('UPDATE vp_customers SET country_of_residence = ? WHERE id = ?');
+            if ($upStmt) {
+                $upStmt->bind_param('si', $country, $customerId);
+                $upStmt->execute();
+                $upStmt->close();
+            }
+        }
+    }
+
+    /**
+     * Ensure vp_customers.country_of_residence is set when selecting a customer.
+     * If country_of_residence is not available (empty/null), update it from vp_order_info.country or pos_customer_details.
+     */
+    public function ensureCountryOfResidenceForCustomer(int $customerId): void
+    {
+        if ($customerId <= 0) {
+            return;
+        }
+
+        $row = $this->getCustomerById($customerId);
+        if (!$row) {
+            return;
+        }
+
+        $existing = trim((string)($row['country_of_residence'] ?? ''));
+        if ($existing !== '') {
+            return;
+        }
+
+        $country = '';
+        $stmt = $this->conn->prepare('SELECT country FROM vp_order_info WHERE customer_id = ? AND country IS NOT NULL AND TRIM(country) <> \'\' ORDER BY id DESC LIMIT 1');
+        if ($stmt) {
+            $stmt->bind_param('i', $customerId);
+            $stmt->execute();
+            $res = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            if ($res && !empty($res['country'])) {
+                $country = trim((string)$res['country']);
+            }
+        }
+
+        if ($country === '') {
+            $this->ensurePosCustomerDetailsTable();
+            $detStmt = $this->conn->prepare('SELECT bill_country, ship_country FROM pos_customer_details WHERE customer_id = ? LIMIT 1');
+            if ($detStmt) {
+                $detStmt->bind_param('i', $customerId);
+                $detStmt->execute();
+                $det = $detStmt->get_result()->fetch_assoc();
+                $detStmt->close();
+                if ($det) {
+                    $country = trim((string)($det['bill_country'] ?? ''));
+                    if ($country === '') {
+                        $country = trim((string)($det['ship_country'] ?? ''));
+                    }
+                }
+            }
+        }
+
+        if ($country !== '') {
+            $upStmt = $this->conn->prepare('UPDATE vp_customers SET country_of_residence = ? WHERE id = ?');
+            if ($upStmt) {
+                $upStmt->bind_param('si', $country, $customerId);
+                $upStmt->execute();
+                $upStmt->close();
+            }
+        }
+    }
+
+    /**
      * Create or update POS customer from modal POST data.
      *
      * @param array<string, mixed> $post
@@ -926,6 +1021,7 @@ class Customer
             }
 
             $this->upsertPosCustomerDetailsFromPost($customerId, $post);
+            $this->updateCustomerCountryOfResidenceFromOrderInfo($customerId, (string)($post['country'] ?? $post['country_of_residence'] ?? ''));
 
             return [
                 'success' => true,
@@ -967,6 +1063,7 @@ class Customer
                     if (!empty($existing['id'])) {
                         $exId = (int)$existing['id'];
                         $this->upsertPosCustomerDetailsFromPost($exId, $post);
+                        $this->updateCustomerCountryOfResidenceFromOrderInfo($exId, (string)($post['country'] ?? $post['country_of_residence'] ?? ''));
                         return [
                             'success' => true,
                             'is_update' => false,
@@ -999,6 +1096,7 @@ class Customer
         }
 
         $this->upsertPosCustomerDetailsFromPost($newId, $post);
+        $this->updateCustomerCountryOfResidenceFromOrderInfo($newId, (string)($post['country'] ?? $post['country_of_residence'] ?? ''));
 
         return [
             'success' => true,

--- a/models/order/order.php
+++ b/models/order/order.php
@@ -2244,7 +2244,11 @@ class Order
         $result = $stmt->get_result();
         if ($result && $result->num_rows > 0) {
             $row = $result->fetch_assoc();
-            return ['success' => true, 'customer_id' => $row['id'], 'message' => 'Customer already exists.'];
+            $cid = (int)$row['id'];
+            require_once __DIR__ . '/../customer/Customer.php';
+            $customerModel = new Customer($this->db);
+            $customerModel->updateCustomerCountryOfResidenceFromOrderInfo($cid, (string)($data['address_info']['country'] ?? ''));
+            return ['success' => true, 'customer_id' => $cid, 'message' => 'Customer already exists.'];
         }
 
         // Insert new customer
@@ -2252,7 +2256,11 @@ class Order
         $stmt = $this->db->prepare($sql);
         $stmt->bind_param('sss', $customer_name, $customer_email, $customer_phone);
         if ($stmt->execute()) {
-            return ['success' => true, 'customer_id' => $stmt->insert_id, 'message' => 'Customer added successfully.'];
+            $cid = (int)$stmt->insert_id;
+            require_once __DIR__ . '/../customer/Customer.php';
+            $customerModel = new Customer($this->db);
+            $customerModel->updateCustomerCountryOfResidenceFromOrderInfo($cid, (string)($data['address_info']['country'] ?? ''));
+            return ['success' => true, 'customer_id' => $cid, 'message' => 'Customer added successfully.'];
         } else {
             return ['success' => false, 'message' => 'Database error: ' . $stmt->error];
         }

--- a/models/posorder/order.php
+++ b/models/posorder/order.php
@@ -2086,7 +2086,11 @@ class POSOrder
         $result = $stmt->get_result();
         if ($result && $result->num_rows > 0) {
             $row = $result->fetch_assoc();
-            return ['success' => true, 'customer_id' => $row['id'], 'message' => 'Customer already exists.'];
+            $cid = (int)$row['id'];
+            require_once __DIR__ . '/../customer/Customer.php';
+            $customerModel = new Customer($this->db);
+            $customerModel->updateCustomerCountryOfResidenceFromOrderInfo($cid, (string)($data['address_info']['country'] ?? ''));
+            return ['success' => true, 'customer_id' => $cid, 'message' => 'Customer already exists.'];
         }
 
         // Insert new customer
@@ -2094,7 +2098,11 @@ class POSOrder
         $stmt = $this->db->prepare($sql);
         $stmt->bind_param('sss', $customer_name, $customer_email, $customer_phone);
         if ($stmt->execute()) {
-            return ['success' => true, 'customer_id' => $stmt->insert_id, 'message' => 'Customer added successfully.'];
+            $cid = (int)$stmt->insert_id;
+            require_once __DIR__ . '/../customer/Customer.php';
+            $customerModel = new Customer($this->db);
+            $customerModel->updateCustomerCountryOfResidenceFromOrderInfo($cid, (string)($data['address_info']['country'] ?? ''));
+            return ['success' => true, 'customer_id' => $cid, 'message' => 'Customer added successfully.'];
         } else {
             return ['success' => false, 'message' => 'Database error: ' . $stmt->error];
         }


### PR DESCRIPTION
Automatically sync country_of_residence in vp_customers from vp_order_info when adding, editing, or selecting a customer in POS register, or creating customer orders.