### PR TITLE
Pass customer country code in x-api-countrycode header for Exotic API…

### DIFF
--- a/controllers/POSRegisterController.php
+++ b/controllers/POSRegisterController.php
@@ -4764,6 +4764,11 @@ class POSRegisterController
             $this->clearPosExoticCartCustomDiscount();
         }
 
+        $checkoutCountry = trim((string)($payload['country_of_residence'] ?? $payload['confirm_country'] ?? $payload['confirm_scountry'] ?? ''));
+        if ($checkoutCountry !== '') {
+            $this->retailApiClient->setCustomerCountryCode($checkoutCountry);
+        }
+
         $ctx = $this->exoticCartDiscountContext();
         $retrieve = $this->retailApiClient->call(
             '/cart/retrieve',

--- a/integrations/exotic/Clients/RetailApiClient.php
+++ b/integrations/exotic/Clients/RetailApiClient.php
@@ -10,6 +10,7 @@ class RetailApiClient
 {
     private ?mysqli $conn;
     private string $defaultBaseUrl;
+    private ?string $customCountryCode = null;
 
     public function __construct(?mysqli $conn = null, string $defaultBaseUrl = 'https://www.exoticindia.com/api')
     {
@@ -74,6 +75,11 @@ class RetailApiClient
         $headers = $this->buildRequestHeaders();
         foreach ($extraHttpHeaders as $line) {
             if (is_string($line) && $line !== '') {
+                if (stripos(trim($line), 'x-api-countrycode:') === 0) {
+                    $headers = array_values(array_filter($headers, function ($h) {
+                        return stripos(trim($h), 'x-api-countrycode:') !== 0;
+                    }));
+                }
                 $headers[] = $line;
             }
         }
@@ -143,16 +149,98 @@ class RetailApiClient
         ];
     }
 
+    public function setCustomerCountryCode(?string $code): self
+    {
+        $code = trim((string)$code);
+        $this->customCountryCode = $code !== '' ? $code : null;
+
+        return $this;
+    }
+
+    public function getCustomerCountryCode(): ?string
+    {
+        return $this->customCountryCode;
+    }
+
+    /**
+     * Resolve ISO 2-letter country code for active customer to pass in x-api-countrycode header.
+     */
+    public function resolveCustomerCountryCode(): string
+    {
+        $conn = $this->conn ?: ($GLOBALS['conn'] instanceof mysqli ? $GLOBALS['conn'] : null);
+
+        if (!empty($this->customCountryCode)) {
+            require_once dirname(__DIR__, 2) . '/helpers/courier/country_codes.php';
+            $iso2 = normalizeCountryIso2($this->customCountryCode, $conn);
+            if (!empty($iso2) && strlen($iso2) === 2 && ctype_alpha($iso2)) {
+                return strtoupper($iso2);
+            }
+        }
+
+        $countryStr = '';
+
+        if (!empty($_SESSION['pos_customer_id'])) {
+            $cid = (int)$_SESSION['pos_customer_id'];
+            if ($cid > 0 && $conn instanceof mysqli) {
+                $stmt = $conn->prepare('SELECT country_of_residence FROM vp_customers WHERE id = ? LIMIT 1');
+                if ($stmt) {
+                    $stmt->bind_param('i', $cid);
+                    $stmt->execute();
+                    $res = $stmt->get_result();
+                    $row = $res ? $res->fetch_assoc() : null;
+                    $stmt->close();
+                    if ($row && !empty($row['country_of_residence'])) {
+                        $countryStr = trim((string)$row['country_of_residence']);
+                    }
+                }
+
+                if ($countryStr === '') {
+                    $detStmt = $conn->prepare('SELECT bill_country, ship_country FROM pos_customer_details WHERE customer_id = ? LIMIT 1');
+                    if ($detStmt) {
+                        $detStmt->bind_param('i', $cid);
+                        $detStmt->execute();
+                        $det = $detStmt->get_result()->fetch_assoc();
+                        $detStmt->close();
+                        if ($det) {
+                            $countryStr = trim((string)($det['bill_country'] ?? ''));
+                            if ($countryStr === '') {
+                                $countryStr = trim((string)($det['ship_country'] ?? ''));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if ($countryStr === '' && !empty($_SESSION['pos_customer_form'])) {
+            $form = $_SESSION['pos_customer_form'];
+            if (is_array($form)) {
+                $countryStr = trim((string)($form['country_of_residence'] ?? $form['country'] ?? ''));
+            }
+        }
+
+        if ($countryStr !== '') {
+            require_once dirname(__DIR__, 2) . '/helpers/courier/country_codes.php';
+            $iso2 = normalizeCountryIso2($countryStr, $conn);
+            if (!empty($iso2) && strlen($iso2) === 2 && ctype_alpha($iso2)) {
+                return strtoupper($iso2);
+            }
+        }
+
+        return 'IN';
+    }
+
     /** @return list<string> */
     public function buildRequestHeaders(): array
     {
         $warehouseId = isset($_SESSION['warehouse_id']) ? (int) $_SESSION['warehouse_id'] : 0;
         $deviceId = RetailApiDeviceIdResolver::resolve($this->conn, $warehouseId > 0 ? $warehouseId : null);
+        $countryCode = $this->resolveCustomerCountryCode();
         $headers = [
             'x-api-key: aeRGoUvQLCxztK0Wzxmv9O2VRJ2H1B44',
             'x-api-deviceid: ' . $deviceId,
             'x-api-appplayerid: POS-Web-Terminal',
-            'x-api-countrycode: IN',
+            'x-api-countrycode: ' . $countryCode,
             'x-api-euid:' . (string) ($_SESSION['x_api_euid'] ?? ''),
             'User-Agent: ExoticPOS',
         ];


### PR DESCRIPTION
… requests

Dynamically resolve customer ISO country code from active customer session or checkout payload and attach x-api-countrycode header on RetailApiClient API calls.