### PR TITLE
Handle unpublished products cart addition in POS register

### DIFF
--- a/assets/js/pos.js
+++ b/assets/js/pos.js
@@ -255,6 +255,9 @@ $(function () {
     $('#modal_item_code').val(normalizeFacet(p.item_code));
     $('#modal_size').val(normalizeFacet(p.size));
     $('#modal_color').val(normalizeFacet(p.color));
+    $('#modal_product_id').val(p.id || p.product_id || '');
+    const isUnpub = (p.published === 0 || p.published === '0' || p.published === false || p.is_published === false || p.status === 0 || p.status === '0' || String(p.status_label || '').toLowerCase() === 'unpublished' || String(p.status || '').toLowerCase() === 'unpublished');
+    $('#modal_published').val(isUnpub ? '0' : '1');
   }
 
   function isMeaningful(val) {
@@ -788,6 +791,7 @@ $(function () {
     }
 
     if (typeof window.handleAddToCart === 'function') {
+      const pubValRaw = $('#modal_published').val();
       window.handleAddToCart({
         code: String($('#modal_product_code').val() || '').trim(),
         qty: qtyNum || getModalQty(),
@@ -796,7 +800,9 @@ $(function () {
         item_level: String($('#modal_item_level').val() || '').trim(),
         item_code: String($('#modal_item_code').val() || '').trim(),
         size: String($('#modal_size').val() || '').trim(),
-        color: String($('#modal_color').val() || '').trim()
+        color: String($('#modal_color').val() || '').trim(),
+        product_id: $('#modal_product_id').val(),
+        published: (pubValRaw === '0' || pubValRaw === 0) ? 0 : 1
       });
     }
   });

--- a/assets/js/pos_cart_hooks.js
+++ b/assets/js/pos_cart_hooks.js
@@ -4734,6 +4734,47 @@
         toast('Missing product code', 'red');
         return undefined;
       }
+
+      // Check if product is unpublished (vp_products.published = 0)
+      var isUnpublished =
+        p.published === 0 ||
+        p.published === '0' ||
+        p.published === false ||
+        p.is_published === false ||
+        p.status === 0 ||
+        p.status === '0' ||
+        String(p.status_label || '').toLowerCase() === 'unpublished' ||
+        String(p.status || '').toLowerCase() === 'unpublished';
+
+      if (!isUnpublished && window.productApiCache) {
+        var cached = window.productApiCache[body.code] || window.productApiCache[body.item_code];
+        if (
+          cached &&
+          (cached.published === 0 ||
+            cached.published === '0' ||
+            cached.published === false ||
+            cached.is_published === false ||
+            cached.status === 0 ||
+            cached.status === '0')
+        ) {
+          isUnpublished = true;
+          if (!p.product_id && cached.id) p.product_id = cached.id;
+        }
+      }
+
+      if (!isUnpublished) {
+        var modalPubVal = $('#modal_published').val();
+        var modalCode = String($('#modal_product_code').val() || '').trim();
+        if ((modalPubVal === '0' || modalPubVal === 0) && modalCode && (modalCode === body.code || modalCode === body.item_code)) {
+          isUnpublished = true;
+          if (!p.product_id) p.product_id = $('#modal_product_id').val();
+        }
+      }
+
+      if (isUnpublished) {
+        return handleUnpublishedAddToCart(p, body);
+      }
+
       setPanelBusy(true);
       var requestedQty = body.qty;
       return cartRequest('add', { method: 'POST', jsonBody: body })
@@ -4780,6 +4821,165 @@
         });
     });
   };
+
+  /**
+   * Handle adding an unpublished product (vp_products.published = 0) to cart:
+   * 1. Show spinner & 5-second timer modal in UI.
+   * 2. In background, set product status to 1 (local DB + Exotic vendor-api).
+   * 3. Wait for 5 seconds AND for status update request to complete.
+   * 4. Add product to cart via cart-api POST add.
+   * 5. Once added (or on error), set product status back to 0 in background.
+   * 6. Hide spinner/timer modal and refresh cart.
+   *
+   * @param {Record<string, unknown>} p
+   * @param {Record<string, unknown>} body
+   */
+  function handleUnpublishedAddToCart(p, body) {
+    var totalSeconds = 5;
+    var productId = p.product_id || p.id || $('#modal_product_id').val() || 0;
+    var itemCode = p.item_code || body.item_code || body.code || '';
+    var sku = p.sku || body.code || '';
+    var size = p.size || body.size || '';
+    var color = p.color || body.color || '';
+
+    var statusParams = {
+      product_id: productId,
+      item_code: itemCode,
+      sku: sku,
+      size: size,
+      color: color
+    };
+
+    setPanelBusy(true);
+    if (typeof window.showUnpublishedProductTimerModal === 'function') {
+      window.showUnpublishedProductTimerModal(totalSeconds);
+    }
+
+    // Step 1: In background set product status = 1
+    var publishPromise = $.ajax({
+      url: '?page=pos_register&action=update-product-published',
+      type: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        product_id: statusParams.product_id,
+        item_code: statusParams.item_code,
+        sku: statusParams.sku,
+        size: statusParams.size,
+        color: statusParams.color,
+        published: 1
+      }),
+      dataType: 'json'
+    });
+
+    // Step 2: 5 second countdown timer
+    var timerPromise = new Promise(function (resolve) {
+      var remaining = totalSeconds;
+      if (typeof window.updateUnpublishedProductTimer === 'function') {
+        window.updateUnpublishedProductTimer(remaining, totalSeconds);
+      }
+      var interval = setInterval(function () {
+        remaining--;
+        if (remaining > 0) {
+          if (typeof window.updateUnpublishedProductTimer === 'function') {
+            window.updateUnpublishedProductTimer(remaining, totalSeconds);
+          }
+        } else {
+          if (typeof window.updateUnpublishedProductTimer === 'function') {
+            window.updateUnpublishedProductTimer(0, totalSeconds);
+          }
+          clearInterval(interval);
+          resolve();
+        }
+      }, 1000);
+    });
+
+    var requestedQty = body.qty;
+    var parentMsg =
+      typeof window.POS_PARENT_ITEM_CART_MSG === 'string'
+        ? window.POS_PARENT_ITEM_CART_MSG
+        : 'Parent Level Item can not be added to the cart';
+
+    // Step 3: Wait for 5 seconds AND status set to 1
+    return Promise.all([timerPromise, publishPromise])
+      .then(function (results) {
+        var publishRes = results[1];
+        if (publishRes && publishRes.success === false) {
+          console.warn('Background publish status response:', publishRes);
+        }
+        if (typeof window.updateUnpublishedProductTimerStatus === 'function') {
+          window.updateUnpublishedProductTimerStatus('Adding product to cart...');
+        }
+        // Step 4: Add to cart
+        return cartRequest('add', { method: 'POST', jsonBody: body });
+      })
+      .then(function (r) {
+        cartHandleApiMessages(r);
+        if (!r.success) {
+          var blockMsg = String(r.message || '');
+          if (
+            blockMsg === parentMsg ||
+            blockMsg.toLowerCase().indexOf('parent level item') !== -1
+          ) {
+            if (typeof window.notifyParentItemCartBlocked === 'function') {
+              window.notifyParentItemCartBlocked();
+            } else {
+              toast(parentMsg, 'red');
+            }
+            return r;
+          }
+          openPosCartApiDebugModal();
+          return r;
+        }
+        toast('Added to cart.', 'green');
+        if (typeof window.closePosProductModal === 'function') {
+          window.closePosProductModal();
+        }
+        var draftRow = window.__posCartDraftRowAfterAdd;
+        if (draftRow) {
+          window.__posCartDraftRowAfterAdd = null;
+          var draftSkuIn = draftRow.querySelector('.pos-cart-draft-sku');
+          if (draftSkuIn) {
+            draftSkuIn.value = '';
+            draftSkuIn.focus();
+          }
+        }
+        return refreshCartInternal().then(function (r2) {
+          if (r2 && r2.data && typeof r2.data === 'object') {
+            toastIfQtyCappedAfterSuccess(requestedQty, r2.data, { code: body.code });
+          }
+          return r2;
+        });
+      })
+      .catch(function (err) {
+        console.error('Error adding unpublished product to cart:', err);
+        toast('Failed to add unpublished product to cart.', 'red');
+      })
+      .finally(function () {
+        // Step 5: Once added to cart (or on failure/error), set status = 0 in background
+        if (typeof window.updateUnpublishedProductTimerStatus === 'function') {
+          window.updateUnpublishedProductTimerStatus('Resetting product status...');
+        }
+        $.ajax({
+          url: '?page=pos_register&action=update-product-published',
+          type: 'POST',
+          contentType: 'application/json',
+          data: JSON.stringify({
+            product_id: statusParams.product_id,
+            item_code: statusParams.item_code,
+            sku: statusParams.sku,
+            size: statusParams.size,
+            color: statusParams.color,
+            published: 0
+          }),
+          dataType: 'json'
+        }).always(function () {
+          if (typeof window.hideUnpublishedProductTimerModal === 'function') {
+            window.hideUnpublishedProductTimerModal();
+          }
+          setPanelBusy(false);
+        });
+      });
+  }
 
   /** @param {Record<string, unknown>} [payload] */
   window.handleUpdateQty = function (payload) {

--- a/controllers/POSRegisterController.php
+++ b/controllers/POSRegisterController.php
@@ -3931,6 +3931,8 @@ class POSRegisterController
         }
 
         $product = [
+            'id' => $vpId,
+            'product_id' => $vpId,
             'requested_code' => $code,
             'item_code' => $dbItemCode,
             'sku' => $dbSku,
@@ -6133,6 +6135,120 @@ class POSRegisterController
             'receipt_signature_date' => $dt->format('d M Y'),
             'payment_history_url' => 'index.php?page=payments&order_number=' . rawurlencode($orderNumber) . '&order_exact=1',
             'invoice_poitem_ids' => $this->resolveInvoicePoitemIdsForOrderNumber($conn, $orderNumber),
+        ];
+    }
+
+    /**
+     * Update product published status in local DB and sync to Exotic India Vendor API.
+     * Used when adding unpublished products to cart in POS register.
+     */
+    public function updateProductPublished(): void
+    {
+        is_login();
+
+        if (strtoupper((string)($_SERVER['REQUEST_METHOD'] ?? '')) !== 'POST') {
+            vendorJsonResponse(['success' => false, 'message' => 'POST request required.']);
+            return;
+        }
+
+        $rawInput = (string)file_get_contents('php://input');
+        $data = json_decode($rawInput, true);
+        if (!is_array($data)) {
+            $data = $_POST;
+        }
+
+        $productId = isset($data['product_id']) ? (int)$data['product_id'] : 0;
+        $itemCode  = trim((string)($data['item_code'] ?? ''));
+        $sku       = trim((string)($data['sku'] ?? ''));
+        $size      = trim((string)($data['size'] ?? ''));
+        $color     = trim((string)($data['color'] ?? ''));
+        $newVal    = isset($data['published']) ? (int)$data['published'] : -1;
+
+        if ($newVal !== 0 && $newVal !== 1) {
+            vendorJsonResponse(['success' => false, 'message' => 'published must be 0 or 1.']);
+            return;
+        }
+
+        global $conn;
+        require_once 'models/product/product.php';
+        $productModel = new \Product($conn);
+
+        $product = null;
+        if ($productId > 0) {
+            $product = $productModel->getProduct($productId);
+        }
+        if (!$product && $itemCode !== '') {
+            $itemCodeRes = $productModel->getProductByItemCode($itemCode);
+            if (is_array($itemCodeRes)) {
+                $product = isset($itemCodeRes['id']) ? $itemCodeRes : ($itemCodeRes[0] ?? null);
+            }
+        }
+        if (!$product && $sku !== '') {
+            $product = $productModel->getProductByskuExact($sku);
+        }
+
+        if (!$product) {
+            vendorJsonResponse(['success' => false, 'message' => 'Product not found.']);
+            return;
+        }
+
+        $resolvedProductId = (int)($product['id'] ?? 0);
+        if ($resolvedProductId <= 0) {
+            vendorJsonResponse(['success' => false, 'message' => 'Invalid product ID.']);
+            return;
+        }
+
+        // 1. Update local database (vp_products.published = 0 or 1)
+        $updated = $productModel->setProductPublished($resolvedProductId, $newVal);
+        if (!$updated) {
+            vendorJsonResponse(['success' => false, 'message' => 'Failed to update product published status in database.']);
+            return;
+        }
+
+        // 2. Sync to Exotic India Vendor API (vendor-api/product/modify status = 0 or 1)
+        $syncItemCode = trim((string)($product['item_code'] ?? $itemCode));
+        $syncSize     = trim((string)($product['size'] ?? $size));
+        $syncColor    = trim((string)($product['color'] ?? $color));
+
+        $vendorSyncResult = $this->syncProductPublishedToVendorApi($syncItemCode, $syncSize, $syncColor, $newVal);
+
+        vendorJsonResponse([
+            'success' => true,
+            'message' => 'Product published status set to ' . $newVal,
+            'product_id' => $resolvedProductId,
+            'published' => $newVal,
+            'vendor_sync' => $vendorSyncResult,
+        ]);
+    }
+
+    private function syncProductPublishedToVendorApi(string $itemCode, string $size, string $color, int $status): array
+    {
+        if ($itemCode === '') {
+            return ['success' => false, 'message' => 'Missing item_code for vendor sync.'];
+        }
+
+        require_once 'helpers/exotic_india_api.php';
+        $endpoint = 'product/modify'
+            . '?itemcode=' . rawurlencode($itemCode)
+            . '&size=' . rawurlencode($size)
+            . '&color=' . rawurlencode($color);
+
+        $postBody = http_build_query(['status' => $status ? 1 : 0]);
+
+        $api = exotic_india_api_post($endpoint, $postBody, ['Content-Type: application/x-www-form-urlencoded']);
+
+        if (!$api['success']) {
+            return [
+                'success' => false,
+                'message' => $api['message'] ?? 'Vendor API call failed.',
+                'http_code' => $api['http_code'] ?? 0,
+            ];
+        }
+
+        return [
+            'success' => true,
+            'message' => 'Vendor published status updated to ' . ($status ? 1 : 0),
+            'response' => $api['data'] ?? [],
         ];
     }
 }

--- a/index.php
+++ b/index.php
@@ -1592,6 +1592,9 @@ switch ($page) {
             case 'save-customer-compliance':
                 $controller->save_customer_compliance();
                 break;
+            case 'update-product-published':
+                $controller->updateProductPublished();
+                break;
             default:
                 $controller->index();
                 break;

--- a/models/pos/pos.php
+++ b/models/pos/pos.php
@@ -209,6 +209,7 @@ class pos
         p.id,
         p.item_code,
         p.sku,
+        p.published,
         p.material,
         p.title,
         p.groupname,

--- a/views/pos_register/index.php
+++ b/views/pos_register/index.php
@@ -889,8 +889,83 @@ if (!empty($selected_customer) && is_array($selected_customer)) {
 </div>
 </div>
 </div>
+  </div>
 </div>
+
+<!-- UNPUBLISHED PRODUCT TIMER MODAL -->
+<div id="unpublishedProductTimerModal" class="fixed inset-0 z-[10010] hidden flex items-center justify-center bg-black/60 backdrop-blur-sm transition-opacity">
+  <div class="relative w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl text-center mx-4">
+    <!-- Spinner -->
+    <div class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-orange-50 ring-8 ring-orange-100/60">
+      <svg class="h-10 w-10 animate-spin text-orange-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+      </svg>
+    </div>
+
+    <h3 class="text-base font-bold text-gray-900 mb-1" id="unpublishedTimerTitle">Virtual Code Product</h3>
+    <p class="text-xs text-gray-600 mb-4 leading-relaxed" id="unpublishedTimerMsg">Activating product status in background before adding to cart...</p>
+
+    <!-- Timer Countdown Badge -->
+    <div class="inline-flex items-center gap-2 rounded-full border border-orange-200 bg-orange-50 px-4 py-2 text-sm font-semibold text-orange-800">
+      <svg class="h-4 w-4 text-orange-600 animate-pulse" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+      </svg>
+      <span>Waiting period: <span id="unpublishedTimerCountdown" class="font-bold text-base text-orange-600">5</span>s</span>
+    </div>
+
+    <!-- Progress Bar -->
+    <div class="mt-5 h-2 w-full overflow-hidden rounded-full bg-gray-100">
+      <div id="unpublishedTimerProgressBar" class="h-full bg-orange-500 transition-all duration-1000 ease-linear" style="width: 100%;"></div>
+    </div>
+  </div>
 </div>
+
+<script>
+  window.showUnpublishedProductTimerModal = function(seconds, titleMsg, textMsg) {
+    seconds = seconds || 5;
+    if (document.getElementById('unpublishedTimerTitle')) {
+      document.getElementById('unpublishedTimerTitle').textContent = titleMsg || 'Virtual Code Product';
+    }
+    if (document.getElementById('unpublishedTimerMsg')) {
+      document.getElementById('unpublishedTimerMsg').textContent = textMsg || 'Activating product status in background before adding to cart...';
+    }
+    if (document.getElementById('unpublishedTimerCountdown')) {
+      document.getElementById('unpublishedTimerCountdown').textContent = seconds;
+    }
+    if (document.getElementById('unpublishedTimerProgressBar')) {
+      document.getElementById('unpublishedTimerProgressBar').style.width = '100%';
+    }
+    var modal = document.getElementById('unpublishedProductTimerModal');
+    if (modal) {
+      modal.classList.remove('hidden');
+    }
+  };
+
+  window.updateUnpublishedProductTimer = function(remainingSeconds, totalSeconds) {
+    totalSeconds = totalSeconds || 5;
+    if (document.getElementById('unpublishedTimerCountdown')) {
+      document.getElementById('unpublishedTimerCountdown').textContent = remainingSeconds;
+    }
+    var pct = Math.max(0, Math.min(100, (remainingSeconds / totalSeconds) * 100));
+    if (document.getElementById('unpublishedTimerProgressBar')) {
+      document.getElementById('unpublishedTimerProgressBar').style.width = pct + '%';
+    }
+  };
+
+  window.updateUnpublishedProductTimerStatus = function(msg) {
+    if (msg && document.getElementById('unpublishedTimerMsg')) {
+      document.getElementById('unpublishedTimerMsg').textContent = msg;
+    }
+  };
+
+  window.hideUnpublishedProductTimerModal = function() {
+    var modal = document.getElementById('unpublishedProductTimerModal');
+    if (modal) {
+      modal.classList.add('hidden');
+    }
+  };
+</script>
 
 <!-- ===== END PAGE WRAPPER ===== -->
 <script src="<?php echo base_url(); ?>assets/js/pos_message_modal.js"></script>

--- a/views/pos_register/partials/product_modal.php
+++ b/views/pos_register/partials/product_modal.php
@@ -126,6 +126,8 @@
 
 
             <input type="hidden" id="modal_product_code" value="">
+            <input type="hidden" id="modal_product_id" value="">
+            <input type="hidden" id="modal_published" value="1">
             <input type="hidden" id="modal_item_code" value="">
             <input type="hidden" id="modal_size" value="">
             <input type="hidden" id="modal_color" value="">


### PR DESCRIPTION
Temporarily activate unpublished products (status = 1) in background, show a 5-second timer modal with spinner, add to cart via cart-api, and reset status to 0 afterwards.