### PR TITLE
Fix missing closing script tag in order detail views

### DIFF
--- a/views/orders/other_partial_order_details.php
+++ b/views/orders/other_partial_order_details.php
@@ -904,6 +904,7 @@ document.getElementById('editOrderPricesForm')?.addEventListener('submit', funct
         }
     });
 });
+</script>
 
 <script>
     function openNoteEditPopup(orderNumber, currentRemarks) {

--- a/views/posorders/other_partial_order_details.php
+++ b/views/posorders/other_partial_order_details.php
@@ -2279,6 +2279,7 @@ document.getElementById('editOrderPricesForm')?.addEventListener('submit', funct
         }
     });
 });
+</script>
 <script>
 let pendingDispatchCancelId = null;
 


### PR DESCRIPTION
Add missing </script> closing tag before downstream script blocks in order detail views, resolving JS syntax error and making openEditPricesModal globally accessible.