### PR TITLE
Disable Edit button on POS order details page.

### DIFF
--- a/controllers/PosOrdersController.php
+++ b/controllers/PosOrdersController.php
@@ -1241,7 +1241,7 @@ class PosOrdersController
                 'proformaPrintUrl' => (string)($proformaPrintAction['url'] ?? ''),
                 'canPrintProforma' => !empty($proformaPrintAction['can_print']),
                 'canEditInvoiceNumber' => canSrEmpAccess(),
-                'canEditOrderPrices' => canSrEmpAccess(),
+                'canEditOrderPrices' => false,
                 'paymentSummary' => $paymentSummary,
                 'canCreateFinalInvoice' => $canCreateFinalInvoice,
                 'canPublishExoticSync' => $canPublishExoticSync,

--- a/views/posorders/other_partial_order_details.php
+++ b/views/posorders/other_partial_order_details.php
@@ -70,7 +70,7 @@ if ($orderCurrencyCode === '') {
 }
 $orderCurrencySymbol = vendor_currency_symbol($orderCurrencyCode);
 $canEditInvoiceNumber = !empty($canEditInvoiceNumber);
-$canEditOrderPrices = !empty($canEditOrderPrices) || (function_exists('canSrEmpAccess') && canSrEmpAccess());
+$canEditOrderPrices = !empty($canEditOrderPrices);
 $invoiceStatus = strtolower(trim((string)($invoiceDisplay['status'] ?? '')));
 $invoiceStatusBadgeClass = match ($invoiceStatus) {
     'final' => 'bg-green-100 text-green-700',
@@ -313,8 +313,6 @@ $proformaPrintDisabledReason = $canPrintProforma
             <?php endif; ?>
             <?php if ($canEditOrderPrices): ?>
                 <button type="button" onclick="openEditPricesModal()" class="rounded border bg-white px-4 py-1.5 text-sm font-medium hover:bg-gray-50 transition-colors">Edit</button>
-            <?php else: ?>
-                <button type="button" disabled title="Sr Emp or higher access required to edit prices" class="rounded border bg-gray-100 text-gray-400 px-4 py-1.5 text-sm font-medium cursor-not-allowed">Edit</button>
             <?php endif; ?>
             <div class="relative inline-block text-left">
                 <input type="checkbox" id="dropdown-toggle" class="peer hidden">


### PR DESCRIPTION
Hide price editing from the outer order details view so users cannot edit order prices from that screen.