### PR TITLE
Fix only_full_group_by error in BusyAccounting item details query

### DIFF
--- a/models/busy/BusyAccounting.php
+++ b/models/busy/BusyAccounting.php
@@ -364,33 +364,57 @@ class BusyAccounting
         // Fetch line items
         $itemsSql = "SELECT it.*, 
                             COALESCE(
-                                NULLIF(CONVERT(ag_p.account_group_name USING utf8mb4) COLLATE utf8mb4_unicode_ci, ''),
-                                NULLIF(CONVERT(p.accounts_group USING utf8mb4) COLLATE utf8mb4_unicode_ci, ''),
-                                NULLIF(CONVERT(ag.account_group_name USING utf8mb4) COLLATE utf8mb4_unicode_ci, ''),
+                                (
+                                    SELECT CONVERT(ag_p.account_group_name USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                                    FROM vp_products p
+                                    LEFT JOIN account_group ag_p ON (
+                                        p.accounts_group IS NOT NULL 
+                                        AND (
+                                            ag_p.id = p.accounts_group 
+                                            OR CONVERT(ag_p.account_group_name USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(p.accounts_group USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                                        )
+                                    )
+                                    WHERE (
+                                        p.id = it.product_id 
+                                        OR (
+                                            it.product_id IS NULL AND it.item_code IS NOT NULL AND it.item_code <> '' 
+                                            AND (
+                                                CONVERT(p.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(it.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci 
+                                                OR CONVERT(p.sku USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(it.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                                            )
+                                        )
+                                    )
+                                    AND ag_p.account_group_name IS NOT NULL AND ag_p.account_group_name <> ''
+                                    LIMIT 1
+                                ),
+                                (
+                                    SELECT CONVERT(p.accounts_group USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                                    FROM vp_products p
+                                    WHERE (
+                                        p.id = it.product_id 
+                                        OR (
+                                            it.product_id IS NULL AND it.item_code IS NOT NULL AND it.item_code <> '' 
+                                            AND (
+                                                CONVERT(p.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(it.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci 
+                                                OR CONVERT(p.sku USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(it.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                                            )
+                                        )
+                                    )
+                                    AND p.accounts_group IS NOT NULL AND p.accounts_group <> ''
+                                    LIMIT 1
+                                ),
+                                (
+                                    SELECT CONVERT(ag.account_group_name USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                                    FROM account_group ag
+                                    WHERE it.groupname IS NOT NULL AND it.groupname <> ''
+                                      AND CONVERT(ag.item_group USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(it.groupname USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                                    LIMIT 1
+                                ),
                                 NULLIF(CONVERT(it.groupname USING utf8mb4) COLLATE utf8mb4_unicode_ci, ''),
                                 CONVERT(it.item_name USING utf8mb4) COLLATE utf8mb4_unicode_ci
                             ) AS account_group_name 
                      FROM vp_invoice_items it 
-                     LEFT JOIN vp_products p ON (
-                         p.id = it.product_id 
-                         OR (
-                             it.product_id IS NULL AND it.item_code IS NOT NULL AND it.item_code <> '' 
-                             AND (
-                                 CONVERT(p.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(it.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci 
-                                 OR CONVERT(p.sku USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(it.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci
-                             )
-                         )
-                     )
-                     LEFT JOIN account_group ag ON CONVERT(it.groupname USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(ag.item_group USING utf8mb4) COLLATE utf8mb4_unicode_ci 
-                     LEFT JOIN account_group ag_p ON (
-                         p.accounts_group IS NOT NULL 
-                         AND (
-                             ag_p.id = p.accounts_group 
-                             OR CONVERT(ag_p.account_group_name USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(p.accounts_group USING utf8mb4) COLLATE utf8mb4_unicode_ci
-                         )
-                     )
-                     WHERE it.invoice_id = ?
-                     GROUP BY it.id";
+                     WHERE it.invoice_id = ?";
         $itemsStmt = $this->conn->prepare($itemsSql);
         $items = [];
         if ($itemsStmt) {
@@ -467,35 +491,59 @@ class BusyAccounting
         // Fetch return line items
         $itemsSql = "SELECT sri.*, ii.item_name, ii.hsn, ii.unit_price, ii.tax_rate, ii.groupname,
                             COALESCE(
-                                NULLIF(CONVERT(ag_p.account_group_name USING utf8mb4) COLLATE utf8mb4_unicode_ci, ''),
-                                NULLIF(CONVERT(p.accounts_group USING utf8mb4) COLLATE utf8mb4_unicode_ci, ''),
-                                NULLIF(CONVERT(ag.account_group_name USING utf8mb4) COLLATE utf8mb4_unicode_ci, ''),
+                                (
+                                    SELECT CONVERT(ag_p.account_group_name USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                                    FROM vp_products p
+                                    LEFT JOIN account_group ag_p ON (
+                                        p.accounts_group IS NOT NULL 
+                                        AND (
+                                            ag_p.id = p.accounts_group 
+                                            OR CONVERT(ag_p.account_group_name USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(p.accounts_group USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                                        )
+                                    )
+                                    WHERE (
+                                        p.id = COALESCE(sri.product_id, ii.product_id) 
+                                        OR (
+                                            sri.product_id IS NULL AND ii.product_id IS NULL AND sri.item_code IS NOT NULL AND sri.item_code <> '' 
+                                            AND (
+                                                CONVERT(p.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(sri.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci 
+                                                OR CONVERT(p.sku USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(sri.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                                            )
+                                        )
+                                    )
+                                    AND ag_p.account_group_name IS NOT NULL AND ag_p.account_group_name <> ''
+                                    LIMIT 1
+                                ),
+                                (
+                                    SELECT CONVERT(p.accounts_group USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                                    FROM vp_products p
+                                    WHERE (
+                                        p.id = COALESCE(sri.product_id, ii.product_id) 
+                                        OR (
+                                            sri.product_id IS NULL AND ii.product_id IS NULL AND sri.item_code IS NOT NULL AND sri.item_code <> '' 
+                                            AND (
+                                                CONVERT(p.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(sri.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci 
+                                                OR CONVERT(p.sku USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(sri.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                                            )
+                                        )
+                                    )
+                                    AND p.accounts_group IS NOT NULL AND p.accounts_group <> ''
+                                    LIMIT 1
+                                ),
+                                (
+                                    SELECT CONVERT(ag.account_group_name USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                                    FROM account_group ag
+                                    WHERE ii.groupname IS NOT NULL AND ii.groupname <> ''
+                                      AND CONVERT(ag.item_group USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(ii.groupname USING utf8mb4) COLLATE utf8mb4_unicode_ci
+                                    LIMIT 1
+                                ),
                                 NULLIF(CONVERT(ii.groupname USING utf8mb4) COLLATE utf8mb4_unicode_ci, ''),
-                                CONVERT(sri.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci,
+                                NULLIF(CONVERT(sri.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci, ''),
                                 CONVERT(ii.item_name USING utf8mb4) COLLATE utf8mb4_unicode_ci
                             ) AS account_group_name 
                      FROM vp_sales_return_items sri 
                      LEFT JOIN vp_invoice_items ii ON sri.invoice_item_id = ii.id 
-                     LEFT JOIN vp_products p ON (
-                         p.id = COALESCE(sri.product_id, ii.product_id) 
-                         OR (
-                             sri.product_id IS NULL AND ii.product_id IS NULL AND sri.item_code IS NOT NULL AND sri.item_code <> '' 
-                             AND (
-                                 CONVERT(p.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(sri.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci 
-                                 OR CONVERT(p.sku USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(sri.item_code USING utf8mb4) COLLATE utf8mb4_unicode_ci
-                             )
-                         )
-                     )
-                     LEFT JOIN account_group ag ON CONVERT(ii.groupname USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(ag.item_group USING utf8mb4) COLLATE utf8mb4_unicode_ci 
-                     LEFT JOIN account_group ag_p ON (
-                         p.accounts_group IS NOT NULL 
-                         AND (
-                             ag_p.id = p.accounts_group 
-                             OR CONVERT(ag_p.account_group_name USING utf8mb4) COLLATE utf8mb4_unicode_ci = CONVERT(p.accounts_group USING utf8mb4) COLLATE utf8mb4_unicode_ci
-                         )
-                     )
-                     WHERE sri.sales_return_id = ?
-                     GROUP BY sri.id";
+                     WHERE sri.sales_return_id = ?";
         $itemsStmt = $this->conn->prepare($itemsSql);
         $items = [];
         if ($itemsStmt) {


### PR DESCRIPTION
Replaced LEFT JOIN and GROUP BY on line items query with correlated scalar subqueries for account_group_name to be fully compatible with sql_mode=only_full_group_by.