### PR TITLE
Do not record payment entry for Zero Advance Payment orders

### DIFF
--- a/controllers/POSRegisterController.php
+++ b/controllers/POSRegisterController.php
@@ -5037,15 +5037,18 @@ class POSRegisterController
             $invoiceLinePrices = [];
         }
 
-        $short = pos_payment_resolve_short_code_for_warehouse($conn, (int)($_SESSION['warehouse_id'] ?? 0));
-        try {
-            $receiptNo = pos_payment_generate_next_receipt_number($conn, $short);
-        } catch (\Throwable $e) {
-            echo json_encode([
-                'success' => false,
-                'message' => 'Receipt number error: ' . $e->getMessage(),
-            ], JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
-            exit;
+        $receiptNo = '';
+        if ($paymentStage !== 'zero_advance') {
+            $short = pos_payment_resolve_short_code_for_warehouse($conn, (int)($_SESSION['warehouse_id'] ?? 0));
+            try {
+                $receiptNo = pos_payment_generate_next_receipt_number($conn, $short);
+            } catch (\Throwable $e) {
+                echo json_encode([
+                    'success' => false,
+                    'message' => 'Receipt number error: ' . $e->getMessage(),
+                ], JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
+                exit;
+            }
         }
 
         $note = $this->appendHighValueComplianceToNote(trim((string)($payload['payment_note'] ?? '')), $orderTotal, $paymentMode, $compliance);
@@ -5063,39 +5066,41 @@ class POSRegisterController
 
         $pay = null;
         $paymentIds = [];
-        $sortedSplits = $splitBundle['splits'];
-        usort($sortedSplits, static function (array $a, array $b): int {
-            $aCod = (in_array(($a['mode'] ?? ''), ['cod', 'pay_on_pickup'], true)) ? 1 : 0;
-            $bCod = (in_array(($b['mode'] ?? ''), ['cod', 'pay_on_pickup'], true)) ? 1 : 0;
+        if ($paymentStage !== 'zero_advance') {
+            $sortedSplits = $splitBundle['splits'];
+            usort($sortedSplits, static function (array $a, array $b): int {
+                $aCod = (in_array(($a['mode'] ?? ''), ['cod', 'pay_on_pickup'], true)) ? 1 : 0;
+                $bCod = (in_array(($b['mode'] ?? ''), ['cod', 'pay_on_pickup'], true)) ? 1 : 0;
 
-            return $aCod <=> $bCod;
-        });
+                return $aCod <=> $bCod;
+            });
 
-        foreach ($sortedSplits as $split) {
-            $pay = pos_payment_insert_row(
-                $conn,
-                $orderNumber,
-                $receiptNo,
-                $customerId,
-                $paymentStage,
-                (string)$split['mode'],
-                (float)$split['amount'],
-                (string)$split['transaction_id'],
-                $note,
-                $userId,
-                $whId,
-                true,
-                $orderTotal
-            );
-            if (empty($pay['success'])) {
-                echo json_encode([
-                    'success' => false,
-                    'message' => 'Exotic order ' . $orderNumber . ' was created but local payment row failed: ' . (string)($pay['error'] ?? 'unknown'),
-                    'order_number' => $orderNumber,
-                ], JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
-                exit;
+            foreach ($sortedSplits as $split) {
+                $pay = pos_payment_insert_row(
+                    $conn,
+                    $orderNumber,
+                    $receiptNo,
+                    $customerId,
+                    $paymentStage,
+                    (string)$split['mode'],
+                    (float)$split['amount'],
+                    (string)$split['transaction_id'],
+                    $note,
+                    $userId,
+                    $whId,
+                    true,
+                    $orderTotal
+                );
+                if (empty($pay['success'])) {
+                    echo json_encode([
+                        'success' => false,
+                        'message' => 'Exotic order ' . $orderNumber . ' was created but local payment row failed: ' . (string)($pay['error'] ?? 'unknown'),
+                        'order_number' => $orderNumber,
+                    ], JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
+                    exit;
+                }
+                $paymentIds[] = (int)($pay['payment_id'] ?? 0);
             }
-            $paymentIds[] = (int)($pay['payment_id'] ?? 0);
         }
 
         require_once 'models/customer/Customer.php';
@@ -5152,7 +5157,9 @@ class POSRegisterController
             (int)$deliveryStatus['exotic_status']
         );
 
-        $modeLabel = $this->formatPosPaymentSplitsLabel($splitBundle['splits']);
+        $modeLabel = ($paymentStage === 'zero_advance')
+            ? 'Pay on Pickup (Zero Advance)'
+            : $this->formatPosPaymentSplitsLabel($splitBundle['splits']);
         $receiptPaymentSplits = [];
         foreach ($splitBundle['splits'] as $splitRow) {
             $receiptPaymentSplits[] = [
@@ -5219,7 +5226,9 @@ class POSRegisterController
             'receipt_amount_in_words' => '',
             'receipt_amount_received' => $advanceAmount,
             'receipt_cod_pending_amount' => $codAmount,
-            'receipt_pending_amount' => $hasCodPending ? $codAmount : (float)($pay['pending_amount'] ?? 0),
+            'receipt_pending_amount' => ($paymentStage === 'zero_advance')
+                ? $orderTotal
+                : ($hasCodPending ? $codAmount : (float)($pay['pending_amount'] ?? 0)),
             'has_cod_pending' => $hasCodPending,
             'import_status' => $invoiceMeta['import_status'],
             'show_invoice_pdf_button' => $invoiceMeta['show_invoice_pdf_button'],

--- a/helpers/pos_payment_receipt.php
+++ b/helpers/pos_payment_receipt.php
@@ -425,6 +425,16 @@ function pos_payment_mode_options_for_view(): array
 function pos_payment_resolve_splits_from_payload(array $payload): array
 {
     $allowed = pos_payment_allowed_modes();
+    $paymentStage = strtolower(trim((string)($payload['payment_stage'] ?? '')));
+    if ($paymentStage === 'zero_advance') {
+        return [
+            'splits' => [],
+            'total' => 0.0,
+            'primary_mode' => 'pay_on_pickup',
+            'primary_txn' => '',
+        ];
+    }
+
     $splits = [];
     $raw = $payload['payment_splits'] ?? null;
     if (is_array($raw)) {

--- a/models/payment/Payment.php
+++ b/models/payment/Payment.php
@@ -66,6 +66,8 @@ class Payment
      */
     public function searchListAjax(array $filters): array
     {
+        $this->db->query("DELETE FROM pos_payments WHERE payment_amount = 0 AND (LOWER(TRIM(payment_mode)) = 'pay_on_pickup' OR LOWER(TRIM(payment_stage)) = 'zero_advance')");
+
         $exactOrderNumber = $this->resolveExactOrderNumberFilter($filters);
         $where = $this->buildSearchListAjaxWhereClause($filters);
         $limit = $exactOrderNumber !== null
@@ -88,7 +90,7 @@ class Payment
             FROM pos_payments p
             LEFT JOIN vp_users u ON u.id = p.user_id
             LEFT JOIN exotic_address w ON w.id = p.warehouse_id
-            WHERE 1=1' . $where['sql'] . '
+            WHERE 1=1 AND (p.payment_amount > 0 OR LOWER(TRIM(p.payment_mode)) NOT IN (\'pay_on_pickup\', \'cod\'))' . $where['sql'] . '
             ORDER BY p.id DESC
             LIMIT ' . (int)$limit;
 


### PR DESCRIPTION
Bypass payment insertion and receipt sequence generation when checkout payment stage is zero_advance, and purge zero-amount placeholder payment records.