### PR TITLE
Fix duplicate line discount row and double deduction in POS summary

### DIFF
--- a/controllers/PosOrdersController.php
+++ b/controllers/PosOrdersController.php
@@ -822,11 +822,14 @@ class PosOrdersController
 
         $lines = [];
 
-        if ($line > 0.001) {
+        $orderLevelDisc = round($coupon + $cash + $gift, 2);
+        $standaloneLineDisc = max(0.0, round($line - $orderLevelDisc, 2));
+
+        if ($standaloneLineDisc > 0.001) {
             $lines[] = [
                 'type' => 'line',
                 'label' => 'Line Discount',
-                'amount' => $line,
+                'amount' => $standaloneLineDisc,
                 'note' => $absorbed ? 'Included in line item prices (list vs discounted price).' : '',
             ];
         }

--- a/helpers/invoice/pos_invoice_amount_summary.php
+++ b/helpers/invoice/pos_invoice_amount_summary.php
@@ -164,10 +164,11 @@ function pos_invoice_build_amount_summary_rows(
             'note' => '',
             'is_grand' => false,
         ];
-        if ($lineDisc > 0.001) {
+        $standaloneLineDisc = max(0.0, round($lineDisc - $orderLevelDisc, 2));
+        if ($standaloneLineDisc > 0.001) {
             $rows[] = [
                 'label' => 'Line Discount',
-                'amount' => $lineDisc,
+                'amount' => $standaloneLineDisc,
                 'note' => $absorbedNote,
                 'is_grand' => false,
             ];

--- a/helpers/invoice/pos_order_pricing.php
+++ b/helpers/invoice/pos_order_pricing.php
@@ -494,9 +494,7 @@ function pos_order_build_order_wide_pricing_components(array $pendingLines, bool
         $orderRow = $pendingLine['order_row'];
         $pricing = $pendingLine['pricing'] ?? [];
         $baseListIncl = pos_order_line_list_price_incl($orderRow);
-        $baseDiscIncl = isset($pricing['chargeable_value']) && (float)$pricing['chargeable_value'] > 0
-            ? (float)$pricing['chargeable_value']
-            : pos_order_inclusive_line_total($orderRow, 'disc');
+        $baseDiscIncl = pos_order_inclusive_line_total($orderRow, 'disc');
         $gstRate = $applyGst ? (float)($orderRow['gst'] ?? 0) : 0.0;
         foreach (pos_order_build_pricing_components($orderRow, $baseListIncl, $baseDiscIncl) as $component) {
             $component['line_id'] = (int)$lineId;
@@ -670,9 +668,7 @@ function pos_order_enrich_line_display_pricing(array $orderRow, array $pricing, 
         $customReduce = $orderCustomReduce > 0
             ? $orderCustomReduce
             : max(0.0, round((float)($orderRow['custom_reduce'] ?? 0), 2));
-        $baseDiscIncl = isset($pricing['chargeable_value']) && (float)$pricing['chargeable_value'] > 0
-            ? (float)$pricing['chargeable_value']
-            : pos_order_inclusive_line_total($orderRow, 'disc');
+        $baseDiscIncl = pos_order_inclusive_line_total($orderRow, 'disc');
         $components = pos_order_build_pricing_components($orderRow, $baseListIncl, $baseDiscIncl);
         $components = pos_order_apply_proportional_custom_reduce($components, $customReduce);
         $taxResult = pos_order_compute_component_tax_rows($components, $gstRate, $applyGst);


### PR DESCRIPTION
Deduct order-level discounts from line discounts in invoice summary rows to eliminate duplicate line discount entries when absorbed. Ensure base discount calculation uses list inclusive total before custom reductions.