### PR TITLE
Fix ONLY_FULL_GROUP_BY error in stock report stats_join subquery

### DIFF
--- a/models/pos/pos.php
+++ b/models/pos/pos.php
@@ -482,7 +482,7 @@ class pos
             'join' => $join,
             'stats_join' => "
             LEFT JOIN (
-                SELECT product_id, sku, COUNT(*) AS movement_count, MIN(running_stock) AS min_running_stock
+                SELECT MAX(product_id) AS product_id, MAX(sku) AS sku, COUNT(*) AS movement_count, MIN(running_stock) AS min_running_stock
                 FROM vp_stock_movements
                 GROUP BY COALESCE(NULLIF(TRIM(sku), ''), CAST(product_id AS CHAR))
             ) sm_stats ON (sm_stats.product_id > 0 AND sm_stats.product_id = p.id)


### PR DESCRIPTION
Wrap product_id and sku in MAX() aggregate functions within sm_stats subquery to satisfy MySQL sql_mode=only_full_group_by strictness.