### PR TITLE
Fix order import skipping items with same item_code but different var…

### DIFF
--- a/controllers/OrdersController.php
+++ b/controllers/OrdersController.php
@@ -2732,11 +2732,25 @@ class OrdersController
         return in_array(strtolower(trim((string)$raw)), ['1', 'true', 'yes', 'on'], true);
     }
 
-    private static function vendorOrderLineMatchKey(string $itemCode, string $sku = ''): string
-    {
-        unset($sku);
+    private static function vendorOrderLineMatchKey(
+        string $itemCode,
+        string $sku = '',
+        string $size = '',
+        string $color = ''
+    ): string {
+        $itemCode = strtolower(trim($itemCode));
+        $sku = strtolower(trim($sku));
+        $size = strtolower(trim($size));
+        $color = strtolower(trim($color));
 
-        return strtolower(trim($itemCode));
+        if ($sku !== '') {
+            return $itemCode . '|' . $sku;
+        }
+        if ($size !== '' || $color !== '') {
+            return $itemCode . '|' . $size . '|' . $color;
+        }
+
+        return $itemCode;
     }
 
     /**
@@ -2911,7 +2925,12 @@ class OrdersController
         $dbLines = $ordersModel->getOrderLinesByOrderNumber($orderNumber);
         $dbByKey = [];
         foreach ($dbLines as $row) {
-            $key = self::vendorOrderLineMatchKey((string)($row['item_code'] ?? ''), (string)($row['sku'] ?? ''));
+            $key = self::vendorOrderLineMatchKey(
+                (string)($row['item_code'] ?? ''),
+                (string)($row['sku'] ?? ''),
+                (string)($row['size'] ?? ''),
+                (string)($row['color'] ?? '')
+            );
             $dbByKey[$key] = $row;
         }
 
@@ -2923,7 +2942,9 @@ class OrdersController
             }
             $itemCode = trim((string)($item['itemcode'] ?? ''));
             $sku = trim((string)($item['sku'] ?? ''));
-            $key = self::vendorOrderLineMatchKey($itemCode, $sku);
+            $size = trim((string)($item['size'] ?? ''));
+            $color = trim((string)($item['color'] ?? ''));
+            $key = self::vendorOrderLineMatchKey($itemCode, $sku, $size, $color);
             $apiStatus = $this->resolveVendorImportStatus($vendorOrder, $item, $statusList);
             $dbRow = $dbByKey[$key] ?? null;
             $dbStatus = $dbRow ? trim((string)($dbRow['status'] ?? '')) : '';

--- a/models/order/order.php
+++ b/models/order/order.php
@@ -604,10 +604,13 @@ class Order
             }
         }
 
-        // Check for duplicate combination (same key as bulk update / refresh upsert)
-        $checkSql = 'SELECT 1 FROM vp_orders WHERE order_number = ? AND item_code = ? LIMIT 1';
+        // Check for duplicate combination (considering order_number, item_code, sku, size, and color)
+        $checkSql = 'SELECT 1 FROM vp_orders WHERE order_number = ? AND item_code = ? AND IFNULL(sku, "") = ? AND IFNULL(size, "") = ? AND IFNULL(color, "") = ? LIMIT 1';
         $checkStmt = $this->db->prepare($checkSql);
-        $checkStmt->bind_param('ss', $data['order_number'], $data['item_code']);
+        $skuVal = (string)($data['sku'] ?? '');
+        $sizeVal = (string)($data['size'] ?? '');
+        $colorVal = (string)($data['color'] ?? '');
+        $checkStmt->bind_param('sssss', $data['order_number'], $data['item_code'], $skuVal, $sizeVal, $colorVal);
         $checkStmt->execute();
         $checkStmt->bind_result($count);
         $checkStmt->fetch();

--- a/models/posorder/order.php
+++ b/models/posorder/order.php
@@ -454,10 +454,13 @@ class POSOrder
             }
         }
 
-        // ✅ Check for duplicate combination
-        $checkSql = "SELECT 1 FROM vp_orders WHERE order_number = ? AND item_code = ? AND sku = ? LIMIT 1";
+        // ✅ Check for duplicate combination (considering order_number, item_code, sku, size, and color)
+        $checkSql = 'SELECT 1 FROM vp_orders WHERE order_number = ? AND item_code = ? AND IFNULL(sku, "") = ? AND IFNULL(size, "") = ? AND IFNULL(color, "") = ? LIMIT 1';
         $checkStmt = $this->db->prepare($checkSql);
-        $checkStmt->bind_param('sss', $data['order_number'], $data['item_code'], $data['sku']);
+        $skuVal = (string)($data['sku'] ?? '');
+        $sizeVal = (string)($data['size'] ?? '');
+        $colorVal = (string)($data['color'] ?? '');
+        $checkStmt->bind_param('sssss', $data['order_number'], $data['item_code'], $skuVal, $sizeVal, $colorVal);
         $checkStmt->execute();
         $checkStmt->bind_result($count);
         $checkStmt->fetch();


### PR DESCRIPTION
…iants

Include sku, size, and color in insertOrder duplicate checks and vendorOrderLineMatchKey mapping to ensure multiple variants of the same item code in an order are properly imported and mapped.