### PR TITLE
Fix custom discount allocation and update logic for POS orders

### DIFF
--- a/helpers/invoice/pos_invoice_amount_summary.php
+++ b/helpers/invoice/pos_invoice_amount_summary.php
@@ -165,7 +165,7 @@ function pos_invoice_build_amount_summary_rows(
             'is_grand' => false,
         ];
         $standaloneLineDisc = max(0.0, round($lineDisc - $orderLevelDisc, 2));
-        if ($standaloneLineDisc > 0.001) {
+        if ($standaloneLineDisc > 0.001 && abs($subInclGst - ($grandTotal + $orderLevelDisc)) > 0.02) {
             $rows[] = [
                 'label' => 'Line Discount',
                 'amount' => $standaloneLineDisc,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updated invoice summary display logic in `helpers/invoice/pos_invoice_amount_summary.php` so that extraneous `Line Discount` metadata is omitted from PDF invoice summary renders when `Total Before Discount` already equals `GRAND Total + Fixed Custom Discount`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfd58583-216c-4e86-938a-8ae13fd74a07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfd58583-216c-4e86-938a-8ae13fd74a07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

